### PR TITLE
Convert git-acp from Bash to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,54 @@
+# Ignore everything by default
+*
+
+# But allow these files
+!.gitignore
+!LICENSE
+!README.md
+!requirements.txt
+!setup.py
+
+# Allow the package directory and Python files
+!git_acp/
+!git_acp/*.py
+!git_acp/__init__.py
+
+# Still ignore Python-specific files even in allowed directories
+**/__pycache__/
+**/*.py[cod]
+**/*$py.class
+**/*.so
+**/.Python
+**/build/
+**/develop-eggs/
+**/dist/
+**/downloads/
+**/eggs/
+**/.eggs/
+**/lib/
+**/lib64/
+**/parts/
+**/sdist/
+**/var/
+**/wheels/
+**/*.egg-info/
+**/.installed.cfg
+**/*.egg
+
+# Virtual environment
+venv/
+env/
+ENV/
+.env/
+.venv/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS specific files
+.DS_Store
+Thumbs.db 

--- a/README.md
+++ b/README.md
@@ -59,24 +59,24 @@ A Python tool to automate Git add, commit, and push actions with optional AI-gen
     python3 -m pipx ensurepath
     ```
 
-2. Install `git_acp`:
+2. Install git-acp:
 
     ```bash
     pipx install git+https://github.com/beecave-homelab/git-acp.git
     ```
 
-The command `git_acp` will now be available globally in your system.
+The command `git-acp` will now be available globally in your system.
 
 To upgrade to the latest version:
 
 ```bash
-pipx upgrade git_acp
+pipx upgrade git-acp
 ```
 
 To uninstall:
 
 ```bash
-pipx uninstall git_acp
+pipx uninstall git-acp
 ```
 
 ### Option 2: Install in a Virtual Environment
@@ -117,10 +117,10 @@ pip install git+https://github.com/beecave-homelab/git-acp.git
 
 ## Usage
 
-After installation, you can use the `git_acp` command from anywhere in your terminal:
+After installation, you can use the `git-acp` command from anywhere in your terminal:
 
 ```bash
-git_acp [OPTIONS]
+git-acp [OPTIONS]
 ```
 
 ### Options
@@ -139,37 +139,37 @@ git_acp [OPTIONS]
 1. Basic usage with interactive file and commit type selection:
 
     ```bash
-    git_acp
+    git-acp
     ```
 
 2. Specify files to add and commit message:
 
     ```bash
-    git_acp -a "file1.py file2.py" -m "Add new features"
+    git-acp -a "file1.py file2.py" -m "Add new features"
     ```
 
 3. Use AI-generated commit message:
 
     ```bash
-    git_acp -o
+    git-acp -o
     ```
 
 4. Push to a specific branch:
 
     ```bash
-    git_acp -b main -m "Update documentation"
+    git-acp -b main -m "Update documentation"
     ```
 
 5. Skip confirmation prompts:
 
     ```bash
-    git_acp -nc -m "Quick fix"
+    git-acp -nc -m "Quick fix"
     ```
 
 6. Override commit type suggestion:
 
     ```bash
-    git_acp -t docs
+    git-acp -t docs
     ```
 
 ## Commit Types

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Python tool to automate Git add, commit, and push actions with optional AI-gen
 
 ## Versions
 
-**Current version**: 0.6.0
+**Current version**: 0.6.1
 
 ## Table of Contents
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,32 @@
 
 A Python tool to automate Git add, commit, and push actions with optional AI-generated commit messages using Ollama. Features a beautiful CLI interface with color-coded output and progress indicators.
 
+## Versions
+
+**Current version**: 0.6.0
+
+## Table of Contents
+
+- [Versions](#versions)
+- [Badges](#badges)
+- [Features](#features)
+- [Prerequisites](#prerequisites)
+- [Installation](#installation)
+- [Usage](#usage)
+- [License](#license)
+- [Contributing](#contributing)
+
+## Badges
+
+![Python](https://img.shields.io/badge/python-3.6%2B-blue)
+![Version](https://img.shields.io/badge/version-0.6.0-brightgreen)
+![License](https://img.shields.io/badge/license-MIT-green)
+
 ## Features
 
 - Automates git add, commit, and push operations
 - Supports AI-generated commit messages using Ollama
-- Automatically classifies commit types with appropriate emojis
+- Interactive commit type selection with automatic suggestions
 - Beautiful CLI interface with color-coded output
 - Progress indicators for long-running operations
 - Follows conventional commit message format
@@ -18,35 +39,77 @@ A Python tool to automate Git add, commit, and push actions with optional AI-gen
 - Python 3.6 or higher
 - Git installed and configured
 - Ollama installed (optional, for AI-generated commit messages)
+- pipx (optional, for global installation)
 
 ## Installation
 
-### Option 1: Install in a Virtual Environment (Recommended)
+### Option 1: Global Installation with pipx (Recommended)
+
+[pipx](https://pypa.github.io/pipx/) is the recommended way to install Python CLI applications globally. It creates isolated environments for each application, ensuring dependency conflicts are avoided.
+
+1. Install pipx if you haven't already:
+
+    ```bash
+    # On macOS
+    brew install pipx
+    pipx ensurepath
+
+    # On Linux
+    python3 -m pip install --user pipx
+    python3 -m pipx ensurepath
+    ```
+
+2. Install `git_acp`:
+
+    ```bash
+    pipx install git+https://github.com/beecave-homelab/git-acp.git
+    ```
+
+The command `git_acp` will now be available globally in your system.
+
+To upgrade to the latest version:
+
+```bash
+pipx upgrade git_acp
+```
+
+To uninstall:
+
+```bash
+pipx uninstall git_acp
+```
+
+### Option 2: Install in a Virtual Environment
 
 1. Clone the repository:
-```bash
-git clone https://github.com/beecave-homelab/git-acp.git
-cd git-acp
-```
+
+    ```bash
+    git clone https://github.com/beecave-homelab/git-acp.git
+    cd git-acp
+    ```
 
 2. Create and activate a virtual environment:
-```bash
-# Create virtual environment
-python -m venv venv
 
-# Activate on macOS/Linux
-source venv/bin/activate
+    ```bash
+    # Create virtual environment
+    python -m venv venv
 
-# Activate on Windows
-# .\venv\Scripts\activate
-```
+    # Activate on macOS/Linux
+    source venv/bin/activate
+
+    # Activate on Windows
+    # .\venv\Scripts\activate
+    ```
 
 3. Install the package:
-```bash
-pip install .
-```
 
-### Option 2: Install Directly from GitHub
+    ```bash
+    pip install .
+    ```
+
+### Option 3: Install Directly with pip
+
+Not recommended for CLI tools, but possible:
 
 ```bash
 pip install git+https://github.com/beecave-homelab/git-acp.git
@@ -54,51 +117,64 @@ pip install git+https://github.com/beecave-homelab/git-acp.git
 
 ## Usage
 
-After installation, you can use the `git-acp` command from anywhere in your terminal:
+After installation, you can use the `git_acp` command from anywhere in your terminal:
 
 ```bash
-git-acp [OPTIONS]
+git_acp [OPTIONS]
 ```
 
 ### Options
 
-- `-a, --add <file>`: Add specified file(s). Defaults to all changed files.
+- `-a, --add <file>`: Add specified file(s). If not specified, shows interactive file selection.
 - `-m, --message <msg>`: Commit message. Defaults to 'Automated commit'.
 - `-b, --branch <branch>`: Specify the branch to push to. Defaults to the current active branch.
 - `-o, --ollama`: Use Ollama AI to generate the commit message.
 - `-nc, --no-confirm`: Skip confirmation prompts for all actions.
+- `-t, --type <type>`: Override automatic commit type suggestion.
+- `-v, --verbose`: Show debug information.
 - `-h, --help`: Show help message.
 
 ### Examples
 
-1. Basic usage (adds all files, uses default commit message):
-```bash
-git-acp
-```
+1. Basic usage with interactive file and commit type selection:
+
+    ```bash
+    git_acp
+    ```
 
 2. Specify files to add and commit message:
-```bash
-git-acp -a "file1.py file2.py" -m "Add new features"
-```
+
+    ```bash
+    git_acp -a "file1.py file2.py" -m "Add new features"
+    ```
 
 3. Use AI-generated commit message:
-```bash
-git-acp -o
-```
+
+    ```bash
+    git_acp -o
+    ```
 
 4. Push to a specific branch:
-```bash
-git-acp -b main -m "Update documentation"
-```
+
+    ```bash
+    git_acp -b main -m "Update documentation"
+    ```
 
 5. Skip confirmation prompts:
-```bash
-git-acp -nc -m "Quick fix"
-```
+
+    ```bash
+    git_acp -nc -m "Quick fix"
+    ```
+
+6. Override commit type suggestion:
+
+    ```bash
+    git_acp -t docs
+    ```
 
 ## Commit Types
 
-The tool automatically classifies commits into the following types:
+The tool suggests commit types based on the changes and allows interactive selection:
 
 - ✨ feat: New features
 - 🐛 fix: Bug fixes
@@ -109,14 +185,12 @@ The tool automatically classifies commits into the following types:
 - 📦 chore: Maintenance tasks
 - ⏪ revert: Reverting changes
 
+The suggested type appears first in the selection list, but you can choose any type using the arrow keys.
+
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT license. See [LICENSE](LICENSE) for more information.
 
-## Author
+## Contributing
 
-elvee
-
-## Version
-
-0.5.0
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/README.md
+++ b/README.md
@@ -1,75 +1,122 @@
 # git-acp
 
-This script automates Git add, commit, and push actions with optional AI-generated commit messages using Ollama.
+A Python tool to automate Git add, commit, and push actions with optional AI-generated commit messages using Ollama. Features a beautiful CLI interface with color-coded output and progress indicators.
 
-## Versions
+## Features
 
-**Current version**: 0.4.0 - Stable release with AI-powered commit message generation
+- Automates git add, commit, and push operations
+- Supports AI-generated commit messages using Ollama
+- Automatically classifies commit types with appropriate emojis
+- Beautiful CLI interface with color-coded output
+- Progress indicators for long-running operations
+- Follows conventional commit message format
+- Configurable through command-line arguments
+- Interactive confirmation prompts (optional)
 
-## Table of Contents
+## Prerequisites
 
-- [Versions](#versions)
-- [Badges](#badges)
-- [Installation](#installation)
-- [Usage](#usage)
-- [License](#license)
-- [Contributing](#contributing)
-
-## Badges
-
-![Bash](https://img.shields.io/badge/Bash-4.0%2B-green)
-![Version](https://img.shields.io/badge/Version-0.4.0-blue)
-![License](https://img.shields.io/badge/License-MIT-yellow)
-![Ollama](https://img.shields.io/badge/AI-Ollama-purple)
+- Python 3.6 or higher
+- Git installed and configured
+- Ollama installed (optional, for AI-generated commit messages)
 
 ## Installation
 
-1. Ensure you have Bash 4.0 or higher installed
-2. If you plan to use AI-generated commit messages:
-   - Install Ollama
-   - Download the `mevatron/diffsense:1.5b` model
-3. Download the `git-acp.sh` script
-4. Make the script executable:
+### Option 1: Install in a Virtual Environment (Recommended)
 
-   ```bash
-   chmod +x git-acp.sh
-   ```
+1. Clone the repository:
+```bash
+git clone https://github.com/beecave-homelab/git-acp.git
+cd git-acp
+```
 
-5. Optionally, move it to your PATH for system-wide access
+2. Create and activate a virtual environment:
+```bash
+# Create virtual environment
+python -m venv venv
+
+# Activate on macOS/Linux
+source venv/bin/activate
+
+# Activate on Windows
+# .\venv\Scripts\activate
+```
+
+3. Install the package:
+```bash
+pip install .
+```
+
+### Option 2: Install Directly from GitHub
+
+```bash
+pip install git+https://github.com/beecave-homelab/git-acp.git
+```
 
 ## Usage
 
-The script supports several options:
+After installation, you can use the `git-acp` command from anywhere in your terminal:
 
 ```bash
 git-acp [OPTIONS]
-
-Options:
-  -a, --add <file>       Add specified file(s). Defaults to all changed files.
-  -m, --message <msg>    Commit message. Defaults to 'Automated commit'.
-  -b, --branch <branch>  Specify the branch to push to. Defaults to current branch.
-  -o, --ollama          Use Ollama AI to generate the commit message.
-  -nc, --no-confirm     Skip confirmation prompts.
-  -h, --help            Show help message.
 ```
 
-Examples:
+### Options
 
+- `-a, --add <file>`: Add specified file(s). Defaults to all changed files.
+- `-m, --message <msg>`: Commit message. Defaults to 'Automated commit'.
+- `-b, --branch <branch>`: Specify the branch to push to. Defaults to the current active branch.
+- `-o, --ollama`: Use Ollama AI to generate the commit message.
+- `-nc, --no-confirm`: Skip confirmation prompts for all actions.
+- `-h, --help`: Show help message.
+
+### Examples
+
+1. Basic usage (adds all files, uses default commit message):
 ```bash
-# Add specific files with a custom commit message
-git-acp -a "file1 file2" -m "Initial commit" -b "develop"
-
-# Use AI to generate commit message for specific files
-git-acp -a "file1 file2" -o
-
-# Quick commit with AI-generated message, no confirmations
-git-acp -a "file1 file2" -o -nc
+git-acp
 ```
+
+2. Specify files to add and commit message:
+```bash
+git-acp -a "file1.py file2.py" -m "Add new features"
+```
+
+3. Use AI-generated commit message:
+```bash
+git-acp -o
+```
+
+4. Push to a specific branch:
+```bash
+git-acp -b main -m "Update documentation"
+```
+
+5. Skip confirmation prompts:
+```bash
+git-acp -nc -m "Quick fix"
+```
+
+## Commit Types
+
+The tool automatically classifies commits into the following types:
+
+- ✨ feat: New features
+- 🐛 fix: Bug fixes
+- 📝 docs: Documentation changes
+- 💎 style: Code style changes
+- ♻️ refactor: Code refactoring
+- 🧪 test: Adding or modifying tests
+- 📦 chore: Maintenance tasks
+- ⏪ revert: Reverting changes
 
 ## License
 
-This project is licensed under the MIT license. See [LICENSE](LICENSE) for more information.
+This project is licensed under the MIT License - see the LICENSE file for details.
 
-## Contributing
+## Author
 
-Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+elvee
+
+## Version
+
+0.5.0

--- a/git_acp/__init__.py
+++ b/git_acp/__init__.py
@@ -1,0 +1,3 @@
+"""Git Add-Commit-Push automation package with AI-powered commit messages."""
+
+__version__ = "0.5.0" 

--- a/git_acp/__main__.py
+++ b/git_acp/__main__.py
@@ -1,0 +1,6 @@
+"""Main entry point for the git-acp package when run with python -m git_acp."""
+
+from git_acp.git_acp import main
+
+if __name__ == "__main__":
+    main() 

--- a/git_acp/git_acp.py
+++ b/git_acp/git_acp.py
@@ -302,7 +302,9 @@ def select_files(files: Set[str]) -> str:
         raise GitError("No changed files found to commit.")
     
     if len(files) == 1:
-        return next(iter(files))
+        file = next(iter(files))
+        rprint(f"[yellow]Adding file:[/yellow] {file}")
+        return file
     
     # Sort files and ensure paths are properly displayed
     choices = sorted(list(files))
@@ -327,6 +329,7 @@ def select_files(files: Set[str]) -> str:
         raise GitError("No files selected.")
     
     if "All files" in selected:
+        rprint("[yellow]Adding all files[/yellow]")
         return "."
         
     return " ".join(f'"{f}"' if ' ' in f else f for f in selected)

--- a/git_acp/git_acp.py
+++ b/git_acp/git_acp.py
@@ -3,7 +3,7 @@
 """
 Script Description: This script automates Git add, commit, and push actions with optional AI-generated commit messages using Ollama.
 Author: elvee
-Version: 0.6.0
+Version: 0.6.1
 License: MIT
 Creation Date: 20-12-2024
 Last Modified: 21-12-2024

--- a/git_acp/git_acp.py
+++ b/git_acp/git_acp.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+
+"""
+Script Description: This script automates Git add, commit, and push actions with optional AI-generated commit messages using Ollama.
+Author: elvee
+Version: 0.5.0
+License: MIT
+Creation Date: 20/12/2024
+Last Modified: 20/12/2024
+"""
+
+import subprocess
+import sys
+from typing import Optional, List, Tuple
+from dataclasses import dataclass
+from enum import Enum
+import click
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Confirm
+from rich import print as rprint
+
+console = Console()
+
+class CommitType(Enum):
+    """Enum for commit types with their corresponding emojis."""
+    FEAT = "feat ✨"
+    FIX = "fix 🐛"
+    DOCS = "docs 📝"
+    STYLE = "style 💎"
+    REFACTOR = "refactor ♻️"
+    TEST = "test 🧪"
+    CHORE = "chore 📦"
+    REVERT = "revert ⏪"
+
+    @classmethod
+    def from_str(cls, type_str: str) -> 'CommitType':
+        """Convert string to CommitType, case insensitive."""
+        try:
+            return cls[type_str.upper()]
+        except KeyError:
+            valid_types = [t.name.lower() for t in cls]
+            raise GitError(
+                f"Invalid commit type: {type_str}. "
+                f"Valid types are: {', '.join(valid_types)}"
+            )
+
+@dataclass
+class GitConfig:
+    """Configuration class for git operations."""
+    files: str = "."
+    message: str = "Automated commit"
+    branch: Optional[str] = None
+    use_ollama: bool = False
+    skip_confirmation: bool = False
+
+class GitError(Exception):
+    """Custom exception for git-related errors."""
+    pass
+
+def run_git_command(command: List[str]) -> Tuple[str, str]:
+    """
+    Run a git command and return its output.
+    
+    Args:
+        command: List of command components
+    
+    Returns:
+        Tuple of (stdout, stderr)
+        
+    Raises:
+        GitError: If the command fails
+    """
+    try:
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True
+        )
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            raise GitError(f"Command failed: {stderr}")
+        return stdout.strip(), stderr.strip()
+    except subprocess.SubprocessError as e:
+        raise GitError(f"Failed to execute git command: {e}")
+
+def get_current_branch() -> str:
+    """Get the name of the current git branch."""
+    stdout, _ = run_git_command(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+    return stdout
+
+def get_git_diff() -> str:
+    """Get the git diff, checking both staged and unstaged changes."""
+    # First try to get staged changes
+    stdout, _ = run_git_command(["git", "diff", "--staged"])
+    if stdout.strip():
+        rprint("[yellow]Debug: Using staged changes diff[/yellow]")
+        return stdout
+    # If no staged changes, get unstaged changes
+    rprint("[yellow]Debug: No staged changes, using unstaged diff[/yellow]")
+    stdout, _ = run_git_command(["git", "diff"])
+    return stdout
+
+def generate_commit_message_with_ollama() -> str:
+    """Generate a commit message using Ollama AI."""
+    try:
+        with console.status("[bold green]Generating commit message with Ollama..."):
+            # Add files first so we can get the diff
+            diff = get_git_diff()
+            if not diff:
+                raise GitError("No changes detected to generate commit message from.")
+            
+            process = subprocess.Popen(
+                ["ollama", "run", "mevatron/diffsense:1.5b"],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True
+            )
+            stdout, stderr = process.communicate(input=diff)
+            if process.returncode != 0:
+                raise GitError(f"Ollama failed: {stderr}")
+            return stdout.strip()
+    except (subprocess.SubprocessError, GitError) as e:
+        raise GitError(f"Failed to generate commit message: {e}")
+
+def classify_commit_type(diff: str) -> CommitType:
+    """
+    Classify the commit type based on the git diff content.
+    
+    Args:
+        diff: The git diff output
+        
+    Returns:
+        CommitType: The classified commit type
+    """
+    # Debug: Print the first few lines of the diff
+    rprint("[yellow]Debug: First 100 characters of diff:[/yellow]")
+    rprint(diff[:100])
+    
+    # Debug: Print which patterns are matching
+    def check_pattern(keywords: List[str], diff_text: str) -> bool:
+        matches = [k for k in keywords if k in diff_text.lower()]
+        if matches:
+            rprint(f"[yellow]Debug: Matched keywords: {matches}[/yellow]")
+        return bool(matches)
+
+    # First check for documentation changes
+    doc_keywords = ["docs/", ".md", "readme", "documentation", "license"]
+    if check_pattern(doc_keywords, diff):
+        rprint("[yellow]Debug: Classified as DOCS[/yellow]")
+        return CommitType.DOCS
+
+    # Then check for test changes
+    test_keywords = ["test", ".test.", "spec", "_test", "test_"]
+    if check_pattern(test_keywords, diff):
+        rprint("[yellow]Debug: Classified as TEST[/yellow]")
+        return CommitType.TEST
+
+    # Check for style changes
+    style_keywords = ["style", "format", "whitespace", "lint", "prettier", "eslint"]
+    if check_pattern(style_keywords, diff):
+        rprint("[yellow]Debug: Classified as STYLE[/yellow]")
+        return CommitType.STYLE
+
+    # Check for refactor
+    refactor_keywords = ["refactor", "restructure", "cleanup", "clean up", "reorganize"]
+    if check_pattern(refactor_keywords, diff):
+        rprint("[yellow]Debug: Classified as REFACTOR[/yellow]")
+        return CommitType.REFACTOR
+
+    # Check for bug fixes
+    fix_keywords = ["fix", "bug", "patch", "issue", "error", "crash", "problem", "resolve"]
+    if check_pattern(fix_keywords, diff):
+        rprint("[yellow]Debug: Classified as FIX[/yellow]")
+        return CommitType.FIX
+
+    # Check for reverts
+    if "revert" in diff.lower():
+        rprint("[yellow]Debug: Classified as REVERT[/yellow]")
+        return CommitType.REVERT
+
+    # Check for features
+    feature_keywords = ["add", "new", "feature", "update", "introduce", 
+                       "implement", "enhance", "create", "improve", "support"]
+    if check_pattern(feature_keywords, diff):
+        rprint("[yellow]Debug: Classified as FEAT[/yellow]")
+        return CommitType.FEAT
+
+    rprint("[yellow]Debug: Defaulting to CHORE[/yellow]")
+    return CommitType.CHORE
+
+def format_commit_message(commit_type: CommitType, message: str) -> str:
+    """
+    Format the commit message according to the conventional commits specification.
+    
+    Args:
+        commit_type: The type of commit
+        message: The commit message
+        
+    Returns:
+        str: The formatted commit message
+    """
+    lines = message.split('\n')
+    title = lines[0]
+    description = '\n'.join(lines[1:])
+    return f"{commit_type.value}: {title}\n\n{description}".strip()
+
+def git_add(files: str) -> None:
+    """Add files to git staging."""
+    with console.status("[bold yellow]Adding files..."):
+        run_git_command(["git", "add", files])
+    rprint("[green]✓[/green] Files added successfully")
+
+def git_commit(message: str) -> None:
+    """Commit staged changes."""
+    with console.status("[bold yellow]Committing changes..."):
+        run_git_command(["git", "commit", "-m", message])
+    rprint("[green]✓[/green] Changes committed successfully")
+
+def git_push(branch: str) -> None:
+    """Push changes to remote repository."""
+    with console.status(f"[bold yellow]Pushing to {branch}..."):
+        run_git_command(["git", "push", "origin", branch])
+    rprint("[green]✓[/green] Changes pushed successfully")
+
+@click.command()
+@click.option('-a', '--add', default=".", help="Add specified file(s). Defaults to all changed files.")
+@click.option('-m', '--message', help="Commit message. Defaults to 'Automated commit'.")
+@click.option('-b', '--branch', help="Specify the branch to push to. Defaults to the current active branch.")
+@click.option('-o', '--ollama', is_flag=True, help="Use Ollama AI to generate the commit message.")
+@click.option('-nc', '--no-confirm', is_flag=True, help="Skip confirmation prompts.")
+@click.option('-t', '--type', 'commit_type',
+              type=click.Choice(['feat', 'fix', 'docs', 'style', 'refactor', 'test', 'chore', 'revert'],
+                              case_sensitive=False),
+              help="Override automatic commit type classification.")
+def main(add: str, message: Optional[str], branch: Optional[str], 
+         ollama: bool, no_confirm: bool, commit_type: Optional[str]) -> None:
+    """
+    Automate git add, commit, and push operations with optional AI-generated commit messages.
+    """
+    try:
+        config = GitConfig(
+            files=add,
+            message=message or "Automated commit",
+            branch=branch,
+            use_ollama=ollama,
+            skip_confirmation=no_confirm
+        )
+
+        if not config.branch:
+            config.branch = get_current_branch()
+
+        # Add files first
+        git_add(config.files)
+
+        if config.use_ollama:
+            config.message = generate_commit_message_with_ollama()
+
+        if not config.message:
+            raise GitError("No commit message provided.")
+
+        # Use provided commit type or classify automatically
+        commit_type_enum = (CommitType.from_str(commit_type) if commit_type 
+                          else classify_commit_type(get_git_diff()))
+        formatted_message = format_commit_message(commit_type_enum, config.message)
+
+        if not config.skip_confirmation:
+            rprint(Panel.fit(
+                formatted_message,
+                title="[bold yellow]Commit Message[/bold yellow]",
+                border_style="yellow"
+            ))
+            if not Confirm.ask("Do you want to proceed?"):
+                rprint("[yellow]Operation cancelled.[/yellow]")
+                return
+
+        git_commit(formatted_message)
+        git_push(config.branch)
+
+        rprint("\n[bold green]🎉 All operations completed successfully![/bold green]")
+
+    except GitError as e:
+        rprint(f"[bold red]Error:[/bold red] {e}")
+        sys.exit(1)
+    except KeyboardInterrupt:
+        rprint("\n[yellow]Operation cancelled by user.[/yellow]")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main() 

--- a/git_acp/git_acp.py
+++ b/git_acp/git_acp.py
@@ -3,10 +3,10 @@
 """
 Script Description: This script automates Git add, commit, and push actions with optional AI-generated commit messages using Ollama.
 Author: elvee
-Version: 0.5.0
+Version: 0.6.0
 License: MIT
-Creation Date: 20/12/2024
-Last Modified: 20/12/2024
+Creation Date: 20-12-2024
+Last Modified: 21-12-2024
 """
 
 import subprocess

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click>=8.0.0
 rich>=10.0.0
+questionary>=1.10.0
 typing;python_version<"3.7" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click>=8.0.0
+rich>=10.0.0
+typing;python_version<"3.7" 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="git-acp",
-    version="0.6.0",
+    version="0.6.1",
     author="elvee",
     author_email="",
     description="A tool to automate Git add, commit, and push with AI-powered commit messages",

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     install_requires=[
         "click>=8.0.0",
         "rich>=10.0.0",
+        "questionary>=1.10.0",
         "typing;python_version<'3.7'",
     ],
 ) 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="git-acp",
-    version="0.5.0",
+    version="0.6.0",
     author="elvee",
     author_email="",
     description="A tool to automate Git add, commit, and push with AI-powered commit messages",

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,40 @@
+from setuptools import setup, find_packages
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+setup(
+    name="git-acp",
+    version="0.5.0",
+    author="elvee",
+    author_email="",
+    description="A tool to automate Git add, commit, and push with AI-powered commit messages",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/beecave-homelab/git-acp",
+    packages=find_packages(),
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Version Control :: Git",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    python_requires=">=3.6",
+    entry_points={
+        "console_scripts": [
+            "git-acp=git_acp.git_acp:main",
+        ],
+    },
+    install_requires=[
+        "click>=8.0.0",
+        "rich>=10.0.0",
+        "typing;python_version<'3.7'",
+    ],
+) 


### PR DESCRIPTION
# Convert git-acp from Bash to Python

This PR converts the git-acp script from Bash to a full-featured Python package with enhanced functionality and a better user experience.

## Major Changes

- Complete rewrite in Python with proper package structure
- Added interactive file selection with multi-select support
- Added interactive commit type selection with automatic suggestions
- Enhanced CLI with color-coded output and progress indicators
- Added verbose mode for debugging
- Added pipx support for better global installation
- Improved error handling and user feedback

## New Features

- Interactive file selection when no files are specified
- Interactive commit type selection with automatic suggestions
- Color-coded output and progress spinners
- Better handling of file paths with spaces
- Support for virtual environments
- Debug mode with verbose output
- Proper Python package structure with setup.py

## Technical Details

- Uses Click for CLI argument parsing
- Uses Rich for beautiful terminal output
- Uses Questionary for interactive prompts
- Follows Python best practices and PEP 8
- Proper error handling with custom exceptions
- Type hints for better code maintainability
- Modular code structure for easier maintenance

## Installation Methods

1. Global installation with pipx (recommended):

   ```bash
   pipx install git+https://github.com/beecave-homelab/git-acp.git
   ```

2. Virtual environment installation:

   ```bash
   python -m venv venv
   source venv/bin/activate
   pip install .
   ```

## Testing Done

- Tested file selection with single and multiple files
- Tested commit type suggestions and selection
- Tested with and without Ollama integration
- Tested path handling with spaces and special characters
- Tested on macOS with Python 3.6+

## Version

- Bumped version to 0.6.1
- Updated documentation to reflect new features
- Added proper version tracking in package

## Breaking Changes

- Command syntax remains the same, but installation method has changed
- Now requires Python 3.6 or higher
- New dependencies: click, rich, questionary

## Documentation

- Updated README with new installation methods
- Added detailed usage examples
- Added proper docstrings throughout the code
- Added type hints for better code understanding