### PR TITLE
Normalize AI-generated commit titles by stripping conventional prefixes and update prompts

### DIFF
--- a/git_acp/ai/ai_utils.py
+++ b/git_acp/ai/ai_utils.py
@@ -354,7 +354,10 @@ def get_commit_context(config: GitConfig) -> dict[str, Any]:
             if config and config.files and config.files != ".":
                 import shlex
 
-                selected_files = shlex.split(config.files)
+                try:
+                    selected_files = shlex.split(config.files)
+                except ValueError as e:
+                    raise GitError(f"Malformed config.files value: {e}") from e
             staged_changes = get_diff("unstaged", config, files=selected_files)
 
             # git diff does not show untracked files.  When the diff is

--- a/git_acp/ai/ai_utils.py
+++ b/git_acp/ai/ai_utils.py
@@ -6,6 +6,7 @@ with support for both simple and advanced context-aware generation.
 
 import json
 import re
+from pathlib import Path
 from typing import Any, cast
 
 import questionary
@@ -293,6 +294,38 @@ brief description
     return prompt
 
 
+def _diff_for_untracked_files(file_paths: list[str]) -> str:
+    """Generate diff-like output for untracked files.
+
+    ``git diff`` does not include untracked files.  This helper reads
+    each file and formats its content as a unified diff so the AI can
+    reason about new files just as it does about modifications.
+
+    Args:
+        file_paths: Repository-relative paths to untracked files.
+
+    Returns:
+        A string resembling ``git diff`` output for the given files.
+    """
+    parts: list[str] = []
+    for file_path in file_paths:
+        try:
+            content = Path(file_path).read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        lines = content.splitlines()
+        numbered = "".join(f"+{line}\n" for line in lines)
+        parts.append(
+            f"diff --git a/{file_path} b/{file_path}\n"
+            f"new file mode 100644\n"
+            f"--- /dev/null\n"
+            f"+++ b/{file_path}\n"
+            f"@@ -0,0 +1,{len(lines)} @@\n"
+            f"{numbered}"
+        )
+    return "\n".join(parts)
+
+
 def get_commit_context(config: GitConfig) -> dict[str, Any]:
     """Gather git context information for commit message generation.
 
@@ -314,7 +347,27 @@ def get_commit_context(config: GitConfig) -> dict[str, Any]:
         if not staged_changes:
             if config and config.verbose:
                 debug_header("No staged changes, checking working directory")
-            staged_changes = get_diff("unstaged", config)
+            # Scope the unstaged diff to the user's selected files so the AI
+            # only sees changes relevant to the intended commit (important in
+            # dry-run mode where files are never actually staged).
+            selected_files: list[str] | None = None
+            if config and config.files and config.files != ".":
+                import shlex
+
+                selected_files = shlex.split(config.files)
+            staged_changes = get_diff("unstaged", config, files=selected_files)
+
+            # git diff does not show untracked files.  When the diff is
+            # still empty and the user selected specific files, generate
+            # diff-like content for any untracked files among them so the
+            # AI can reason about new files.
+            if not staged_changes and selected_files:
+                from git_acp.git import get_changed_files
+
+                all_changed = get_changed_files(config, staged_only=False)
+                untracked = [f for f in selected_files if f in all_changed]
+                if untracked:
+                    staged_changes = _diff_for_untracked_files(untracked)
 
         if config and config.verbose:
             debug_header("Fetching commit history")

--- a/git_acp/ai/ai_utils.py
+++ b/git_acp/ai/ai_utils.py
@@ -199,7 +199,7 @@ def create_structured_advanced_commit_message_prompt(
     )
 
     prompt = f"""<task>
-Generate an accurate, contextually-aware conventional commit message
+Generate an accurate, contextually-aware commit message subject and optional body
 for the provided git changes.
 </task>
 
@@ -224,15 +224,18 @@ Follow repository patterns:
 1. Match repository commit style and patterns
 2. Be specific about changes and rationale
 3. Reference related commits when relevant
-4. Use appropriate commit scope
+4. Use optional scope text in the subject only when helpful
 5. Keep title under 72 chars, body well-formatted
 6. Output only the commit message, no additional text, comments or explanations.
 7. Do not mention these instructions, formatting rules, or the prompt itself.
 8. Avoid meta commentary about following guidelines.
+9. Do NOT include a commit type prefix (for example `feat:`, `fix:`,
+   `refactor(scope):`, or emoji-prefixed types) in the title.
 </requirements>
 
 <output_format>
-(scope): descriptive title
+descriptive title
+[optional scope in plain text, no conventional prefix]
 
 Explain what changed and why (no meta commentary).
 Reference to related work if applicable.
@@ -259,7 +262,7 @@ def create_structured_simple_commit_message_prompt(
         Structured prompt for the AI model.
     """
     prompt = f"""<task>
-Generate a conventional commit message for the provided git changes.
+Generate a commit message subject and optional body for the provided git changes.
 </task>
 
 <changes>
@@ -273,6 +276,8 @@ Generate a conventional commit message for the provided git changes.
 4. Output only the commit description, no additional text, comments or explanations.
 5. Do not mention these instructions, formatting rules, or the prompt itself.
 6. Avoid meta commentary about following guidelines.
+7. Do NOT include a conventional commit type prefix in the title (for example
+   `feat:`, `fix:`, `docs(scope):`, or emoji-prefixed types).
 </requirements>
 
 <output_format>

--- a/git_acp/cli/workflow.py
+++ b/git_acp/cli/workflow.py
@@ -21,6 +21,7 @@ from git_acp.git import (
     git_add,
     git_commit,
     git_push,
+    strip_conventional_prefix,
     unstage_files,
 )
 from git_acp.utils.file_filter import filter_files_by_scope
@@ -416,7 +417,7 @@ class GitWorkflow:
         """
         message = self.config.message or ""
         lines = message.split("\n")
-        title = lines[0]
+        title = strip_conventional_prefix(lines[0])
         description = "\n".join(lines[1:])
         return f"{commit_type.value}: {title}\n\n{description}".strip()
 

--- a/git_acp/git/__init__.py
+++ b/git_acp/git/__init__.py
@@ -6,6 +6,7 @@ from git_acp.git.classification import (
     CommitType,
     classify_commit_type,
     group_changed_files,
+    strip_conventional_prefix,
 )
 from git_acp.git.history import (
     analyze_commit_patterns,
@@ -41,5 +42,6 @@ __all__ = [
     "CommitType",
     "classify_commit_type",
     "group_changed_files",
+    "strip_conventional_prefix",
     "setup_signal_handlers",
 ]

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -12,6 +12,7 @@ Classification Priority:
 """
 
 import re
+import shlex
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
@@ -24,6 +25,7 @@ from git_acp.config import (
 )
 from git_acp.git.git_operations import GitError, get_changed_files, get_diff
 from git_acp.utils import OptionalConfig, debug_header, debug_item
+from git_acp.utils.file_filter import filter_files_by_scope
 
 
 class CommitType(Enum):
@@ -98,8 +100,6 @@ def get_changes(config: OptionalConfig = None) -> str:
                 and config.files
                 and config.files != "."
             ):
-                import shlex
-
                 selected_files = shlex.split(config.files)
             diff = get_diff("unstaged", config, files=selected_files)
 
@@ -532,7 +532,7 @@ def strip_conventional_prefix(title: str) -> str:
     match = pattern.match(title)
     if not match:
         return title
-    return (match.group("breaking") or "") + match.group("body").lstrip()
+    return match.group("body").lstrip()
 
 
 def classify_commit_type(config, commit_message: str | None = None) -> CommitType:
@@ -581,8 +581,6 @@ def classify_commit_type(config, commit_message: str | None = None) -> CommitTyp
                     and config.files
                     and config.files != "."
                 ):
-                    from git_acp.utils.file_filter import filter_files_by_scope
-
                     changed_files = filter_files_by_scope(changed_files, config.files)
         except GitError:
             changed_files = set()

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -502,13 +502,13 @@ def strip_conventional_prefix(title: str) -> str:
         commit_type.name.lower() for commit_type in CommitType
     )
     pattern = re.compile(
-        rf"^\s*(?:{commit_type_pattern})\s*(?:\([^)]+\))?\s*[^A-Za-z0-9_]*:\s*(?P<body>.+)$",
+        rf"^\s*(?:{commit_type_pattern})\s*(?:\([^)]+\))?(?P<breaking>!?):\s*(?P<body>.+)$",
         flags=re.IGNORECASE,
     )
     match = pattern.match(title)
     if not match:
         return title
-    return match.group("body").lstrip()
+    return (match.group("breaking") or "") + match.group("body").lstrip()
 
 
 def classify_commit_type(config, commit_message: str | None = None) -> CommitType:

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -479,6 +479,38 @@ def _parse_message_prefix(commit_title: str, config) -> CommitType | None:
     return parsed_type
 
 
+def strip_conventional_prefix(title: str) -> str:
+    """Strip a conventional-commit prefix from a title when present.
+
+    Supported prefixes include:
+        - ``type: ...``
+        - ``type(scope): ...``
+        - ``type emoji: ...``
+        - ``type(scope) emoji: ...``
+
+    Args:
+        title: Candidate commit title.
+
+    Returns:
+        Title without the leading conventional prefix, or the original title if
+        no valid conventional prefix is present.
+    """
+    if not title:
+        return title
+
+    commit_type_pattern = "|".join(
+        commit_type.name.lower() for commit_type in CommitType
+    )
+    pattern = re.compile(
+        rf"^\s*(?:{commit_type_pattern})\s*(?:\([^)]+\))?\s*[^A-Za-z0-9_]*:\s*(?P<body>.+)$",
+        flags=re.IGNORECASE,
+    )
+    match = pattern.match(title)
+    if not match:
+        return title
+    return match.group("body").lstrip()
+
+
 def classify_commit_type(config, commit_message: str | None = None) -> CommitType:
     """Classify the commit type based on file paths, message, and diff content.
 

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -501,8 +501,14 @@ def strip_conventional_prefix(title: str) -> str:
     commit_type_pattern = "|".join(
         commit_type.name.lower() for commit_type in CommitType
     )
+    _emojis = {
+        part for ct in CommitType for part in ct.value.split() if not part.isascii()
+    }
+    emoji_pattern = "|".join(re.escape(e) for e in sorted(_emojis))
     pattern = re.compile(
-        rf"^\s*(?:{commit_type_pattern})\s*(?:\([^)]+\))?(?P<breaking>!?):\s*(?P<body>.+)$",
+        rf"^\s*(?:{commit_type_pattern})(?:\s+(?:{emoji_pattern}))?\s*"
+        rf"(?:\([^)]+\))?(?:\s+(?:{emoji_pattern}))?\s*"
+        r"(?P<breaking>!?):\s*(?P<body>.+)$",
         flags=re.IGNORECASE,
     )
     match = pattern.match(title)

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -23,7 +23,7 @@ from git_acp.config import (
     FILE_PATH_PATTERNS,
 )
 from git_acp.git.git_operations import GitError, get_changed_files, get_diff
-from git_acp.utils import debug_header, debug_item
+from git_acp.utils import OptionalConfig, debug_header, debug_item
 
 
 class CommitType(Enum):
@@ -69,8 +69,15 @@ class CommitType(Enum):
         )
 
 
-def get_changes() -> str:
+def get_changes(config: OptionalConfig = None) -> str:
     """Retrieve the staged or unstaged changes in the repository.
+
+    When ``config`` is provided and specifies particular files, the
+    unstaged diff is scoped to those files only so that unrelated
+    working-directory changes do not influence classification.
+
+    Args:
+        config: Optional configuration for scoping and verbose output.
 
     Returns:
         str: The changes as a diff string
@@ -80,10 +87,21 @@ def get_changes() -> str:
     """
     try:
         # First try staged changes
-        diff = get_diff("staged")
+        diff = get_diff("staged", config)
         if not diff:
-            # If no staged changes, get unstaged changes
-            diff = get_diff("unstaged")
+            # If no staged changes, get unstaged changes scoped to
+            # the user's selected files when applicable.
+            selected_files: list[str] | None = None
+            if (
+                config
+                and isinstance(config.files, str)
+                and config.files
+                and config.files != "."
+            ):
+                import shlex
+
+                selected_files = shlex.split(config.files)
+            diff = get_diff("unstaged", config, files=selected_files)
 
         if not diff:
             raise GitError("No changes detected in the repository.")
@@ -554,6 +572,18 @@ def classify_commit_type(config, commit_message: str | None = None) -> CommitTyp
             changed_files = get_changed_files(config, staged_only=True)
             if not changed_files:
                 changed_files = get_changed_files(config, staged_only=False)
+                # When specific files were selected (e.g. via interactive
+                # prompt or -a), scope classification to those files only
+                # so unrelated changes don't influence the type.
+                if (
+                    changed_files
+                    and isinstance(config.files, str)
+                    and config.files
+                    and config.files != "."
+                ):
+                    from git_acp.utils.file_filter import filter_files_by_scope
+
+                    changed_files = filter_files_by_scope(changed_files, config.files)
         except GitError:
             changed_files = set()
 
@@ -590,29 +620,33 @@ def classify_commit_type(config, commit_message: str | None = None) -> CommitTyp
                     raise GitError(msg) from e
 
         # Priority 4: Diff-based keyword matching (fallback)
-        diff = get_changes()
+        try:
+            diff = get_changes(config)
+        except GitError:
+            diff = None
 
-        for commit_type, keywords in COMMIT_TYPE_PATTERNS.items():
-            try:
-                matches = _check_keyword_pattern(
-                    keywords, diff, use_word_boundaries=False, config=config
-                )
-                if matches:
+        if diff:
+            for commit_type, keywords in COMMIT_TYPE_PATTERNS.items():
+                try:
+                    matches = _check_keyword_pattern(
+                        keywords, diff, use_word_boundaries=False, config=config
+                    )
+                    if matches:
+                        if config.verbose:
+                            debug_header("Commit Classification Result")
+                            debug_item("Selected Type", commit_type.upper())
+                            debug_item("Source", "git_diff")
+                        return CommitType[commit_type.upper()]
+                except KeyError as e:
                     if config.verbose:
-                        debug_header("Commit Classification Result")
-                        debug_item("Selected Type", commit_type.upper())
-                        debug_item("Source", "git_diff")
-                    return CommitType[commit_type.upper()]
-            except KeyError as e:
-                if config.verbose:
-                    debug_header("Invalid Commit Type")
-                    debug_item("Type", commit_type)
-                    debug_item("Error", str(e))
-                msg = (
-                    f"Invalid commit type pattern: {commit_type}. "
-                    "Check commit type definitions."
-                )
-                raise GitError(msg) from e
+                        debug_header("Invalid Commit Type")
+                        debug_item("Type", commit_type)
+                        debug_item("Error", str(e))
+                    msg = (
+                        f"Invalid commit type pattern: {commit_type}. "
+                        "Check commit type definitions."
+                    )
+                    raise GitError(msg) from e
 
         # Priority 5: Default to CHORE
         if config.verbose:

--- a/git_acp/git/diff.py
+++ b/git_acp/git/diff.py
@@ -89,12 +89,18 @@ def get_changed_files(
     return files
 
 
-def get_diff(diff_type: DiffType = "staged", config: OptionalConfig = None) -> str:
+def get_diff(
+    diff_type: DiffType = "staged",
+    config: OptionalConfig = None,
+    files: list[str] | None = None,
+) -> str:
     """Get the git diff output for staged or unstaged changes.
 
     Args:
         diff_type: Type of diff to retrieve ('staged' or 'unstaged').
         config: Optional configuration for verbose output.
+        files: Optional list of file paths to scope the diff to.
+            When provided, only changes to these files are included.
 
     Returns:
         str: The diff output as a string.
@@ -106,10 +112,14 @@ def get_diff(diff_type: DiffType = "staged", config: OptionalConfig = None) -> s
         if config and config.verbose:
             debug_header(f"Getting {diff_type} diff")
 
-        if diff_type == "staged":
-            stdout, _ = run_git_command(["git", "diff", "--staged"], config)
-        else:
-            stdout, _ = run_git_command(["git", "diff"], config)
+        cmd: list[str] = (
+            ["git", "diff", "--staged"] if diff_type == "staged" else ["git", "diff"]
+        )
+        if files:
+            cmd.append("--")
+            cmd.extend(files)
+
+        stdout, _ = run_git_command(cmd, config)
 
         if config and config.verbose:
             debug_item("Diff length", str(len(stdout)))

--- a/project-overview.md
+++ b/project-overview.md
@@ -1,7 +1,7 @@
 ---
 repo: https://github.com/beecave-homelab/git-acp.git
-commit: 893e969bfd0c97c23fde2ff6113a945f43c91009
-updated: 2026-01-13T22:01:27Z
+commit: 767c01d
+updated: 2026-05-15T00:00:00Z
 ---
 <!-- markdownlint-disable-file MD033 -->
 <!-- SECTIONS:API,CLI,WEBUI,CI,DOCKER,TESTS -->
@@ -78,6 +78,7 @@ pdm export --pyproject --no-hashes -G lint,test -o requirements.dev.txt
 - Interactive staging of changed files.
 - AI-generated commit messages using Ollama.
 - **Smart commit type classification** using file-path-first heuristics with keyword fallback.
+- **Prefix-safe commit title formatting**: workflow strips AI-provided conventional prefixes before applying the selected commit type, preventing duplicate type prefixes.
 - **Auto-group mode** (`-ag/--auto-group`) to split unstaged changes into multiple focused commits using deterministic file grouping.
 - **Scoped `-a` filtering** that supports glob patterns (including `**/`), ensuring dry-run and file listings match the intended paths.
 - Support for Conventional Commits specification.
@@ -141,6 +142,7 @@ tests/
 - **Modular Design**: Separate packages for AI, CLI, git operations, and configuration.
 - **SOLID Principles**: Single Responsibility (workflow vs CLI), Dependency Inversion (protocols).
 - **Auto-group orchestration**: CLI can iterate deterministic file groups and run multiple workflow instances safely.
+- **AI output normalization**: prompt templates and formatting logic are aligned so AI returns description-first titles while workflow applies a single canonical type prefix.
 
 ### Component Interaction Diagram
 

--- a/tests/ai/test_ai_utils.py
+++ b/tests/ai/test_ai_utils.py
@@ -10,6 +10,7 @@ import pytest
 
 from git_acp.ai.ai_utils import (
     AIClient,
+    _strip_meta_commentary,
     calculate_context_budget,
     create_structured_advanced_commit_message_prompt,
     create_structured_simple_commit_message_prompt,
@@ -193,6 +194,7 @@ def test_create_advanced_prompt(mock_context, mock_config):
     assert "<changes>" in prompt
     assert "<requirements>" in prompt
     assert "<output_format>" in prompt
+    assert "Do NOT include a commit type prefix" in prompt
 
 
 def test_create_simple_prompt(mock_context, mock_config):
@@ -204,6 +206,7 @@ def test_create_simple_prompt(mock_context, mock_config):
     assert "<requirements>" in prompt
     assert "<output_format>" in prompt
     assert mock_context["staged_changes"] in prompt
+    assert "Do NOT include a conventional commit type prefix" in prompt
 
 
 # Message Editing Tests
@@ -662,3 +665,25 @@ class TestEditCommitMessageVerbose:
         result = edit_commit_message("feat: original", interactive_verbose_config)
 
         assert result == "feat: original"
+
+
+class TestStripMetaCommentary:
+    """Tests for removing meta commentary from AI-generated messages."""
+
+    def test_strip_meta_commentary__preserves_title_and_strips_meta_body(self) -> None:
+        """Keep title unchanged while removing body lines with meta commentary."""
+        message = (
+            "fix 🐛: add validation\n\n"
+            "Follow prompt instructions and best practices.\n"
+            "Add robust validation for edge cases."
+        )
+
+        assert _strip_meta_commentary(message) == (
+            "fix 🐛: add validation\n\nAdd robust validation for edge cases."
+        )
+
+    def test_strip_meta_commentary__keeps_conventional_prefix_in_title(self) -> None:
+        """Do not alter conventional prefixes that appear in the title."""
+        message = "refactor(core) ♻️: simplify parser\n\nimprove readability"
+
+        assert _strip_meta_commentary(message) == message

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -737,3 +737,64 @@ class TestFormatCommitMessage:
 
         assert result.startswith(CommitType.DOCS.value)
         assert result.endswith("update readme")
+
+
+class TestWorkflowFormatMessage:
+    """Tests for GitWorkflow._format_message normalization behavior."""
+
+    def test_format_message__does_not_duplicate_existing_prefix(self) -> None:
+        """Keep a single prefix when AI output already contains one."""
+        from git_acp.cli.interaction import TestInteraction
+        from git_acp.cli.workflow import GitWorkflow
+
+        config = GitConfig(
+            files="test.py",
+            message="fix 🐛: add validation",
+            branch="main",
+            use_ollama=False,
+            interactive=False,
+            skip_confirmation=True,
+            verbose=False,
+            prompt_type="simple",
+        )
+        workflow = GitWorkflow(config, TestInteraction())
+
+        assert workflow._format_message(CommitType.FIX) == "fix 🐛: add validation"
+
+    def test_format_message__replaces_existing_prefix_when_type_changes(self) -> None:
+        """Replace existing prefix and scope with selected classification type."""
+        from git_acp.cli.interaction import TestInteraction
+        from git_acp.cli.workflow import GitWorkflow
+
+        config = GitConfig(
+            files="test.py",
+            message="fix(auth): add validation",
+            branch="main",
+            use_ollama=False,
+            interactive=False,
+            skip_confirmation=True,
+            verbose=False,
+            prompt_type="simple",
+        )
+        workflow = GitWorkflow(config, TestInteraction())
+
+        assert workflow._format_message(CommitType.FEAT) == "feat ✨: add validation"
+
+    def test_format_message__adds_prefix_when_missing(self) -> None:
+        """Add selected prefix when AI output has no conventional prefix."""
+        from git_acp.cli.interaction import TestInteraction
+        from git_acp.cli.workflow import GitWorkflow
+
+        config = GitConfig(
+            files="test.py",
+            message="add new feature",
+            branch="main",
+            use_ollama=False,
+            interactive=False,
+            skip_confirmation=True,
+            verbose=False,
+            prompt_type="simple",
+        )
+        workflow = GitWorkflow(config, TestInteraction())
+
+        assert workflow._format_message(CommitType.FEAT) == "feat ✨: add new feature"

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -780,6 +780,25 @@ class TestWorkflowFormatMessage:
 
         assert workflow._format_message(CommitType.FEAT) == "feat ✨: add validation"
 
+    def test_format_message__strips_breaking_indicator_when_type_changes(self) -> None:
+        """Remove breaking-change "!" indicator when replacing the prefix."""
+        from git_acp.cli.interaction import TestInteraction
+        from git_acp.cli.workflow import GitWorkflow
+
+        config = GitConfig(
+            files="test.py",
+            message="fix!: add validation",
+            branch="main",
+            use_ollama=False,
+            interactive=False,
+            skip_confirmation=True,
+            verbose=False,
+            prompt_type="simple",
+        )
+        workflow = GitWorkflow(config, TestInteraction())
+
+        assert workflow._format_message(CommitType.FEAT) == "feat ✨: add validation"
+
     def test_format_message__adds_prefix_when_missing(self) -> None:
         """Add selected prefix when AI output has no conventional prefix."""
         from git_acp.cli.interaction import TestInteraction

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -565,3 +565,12 @@ class TestStripConventionalPrefix:
     def test_strip_conventional_prefix__empty(self) -> None:
         """Return empty input unchanged."""
         assert strip_conventional_prefix("") == ""
+
+    def test_strip_conventional_prefix__breaking_marker(self) -> None:
+        """Strip the breaking-change indicator along with the prefix."""
+        assert strip_conventional_prefix("fix!: breaking API") == "breaking API"
+
+    def test_strip_conventional_prefix__case_insensitive(self) -> None:
+        """Normalize case-insensitive conventional prefixes."""
+        assert strip_conventional_prefix("Fix: description") == "description"
+        assert strip_conventional_prefix("FEAT(scope): description") == "description"

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -10,6 +10,7 @@ from git_acp.git.classification import (
     _classify_by_file_paths,
     classify_commit_type,
     get_changes,
+    strip_conventional_prefix,
 )
 from git_acp.git.git_operations import GitError
 
@@ -528,3 +529,38 @@ class TestClassifyCommitTypeEdgeCases:
         assert result == CommitType.TEST
         mock_debug_header.assert_any_call("Commit Classification Result")
         mock_debug_item.assert_any_call("Source", "file_paths")
+
+
+class TestStripConventionalPrefix:
+    """Tests for stripping conventional prefixes from commit titles."""
+
+    def test_strip_conventional_prefix__type_only(self) -> None:
+        """Strip simple ``type:`` prefixes."""
+        assert strip_conventional_prefix("fix: description") == "description"
+
+    def test_strip_conventional_prefix__type_with_scope(self) -> None:
+        """Strip ``type(scope):`` prefixes."""
+        assert strip_conventional_prefix("feat(scope): description") == "description"
+
+    def test_strip_conventional_prefix__type_with_emoji(self) -> None:
+        """Strip ``type emoji:`` prefixes."""
+        assert strip_conventional_prefix("fix 🐛: description") == "description"
+
+    def test_strip_conventional_prefix__type_scope_and_emoji(self) -> None:
+        """Strip ``type(scope) emoji:`` prefixes."""
+        message = "refactor(core) ♻️: description"
+        assert strip_conventional_prefix(message) == "description"
+
+    def test_strip_conventional_prefix__no_prefix(self) -> None:
+        """Leave non-conventional titles unchanged."""
+        message = "add feature: with colon in body"
+        assert strip_conventional_prefix(message) == message
+
+    def test_strip_conventional_prefix__invalid_partial_prefix(self) -> None:
+        """Avoid stripping invalid partial prefixes."""
+        message = "fix update: description"
+        assert strip_conventional_prefix(message) == message
+
+    def test_strip_conventional_prefix__empty(self) -> None:
+        """Return empty input unchanged."""
+        assert strip_conventional_prefix("") == ""

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -168,12 +168,14 @@ class TestClassification:
 
     @patch("git_acp.git.classification.get_changed_files")
     @patch("git_acp.git.classification.get_diff")
-    def test_no_changes_error(self, mock_get_diff, mock_get_files, mock_config):
-        """Raise GitError when diff is empty."""
+    def test_no_changes_defaults_to_chore(
+        self, mock_get_diff, mock_get_files, mock_config
+    ):
+        """Default to CHORE when diff is empty and no classification matches."""
         mock_get_files.return_value = set()
         mock_get_diff.return_value = ""
-        with pytest.raises(GitError):
-            classify_commit_type(mock_config)
+        result = classify_commit_type(mock_config)
+        assert result == CommitType.CHORE
 
     @patch("git_acp.git.classification.get_changed_files")
     @patch("git_acp.git.classification.get_diff")
@@ -396,15 +398,14 @@ class TestClassifyCommitTypeEdgeCases:
         mock_get_files,
         verbose_config,
     ):
-        """Log error details in verbose mode when GitError occurs."""
+        """Default to CHORE when get_diff raises GitError (e.g. no diff)."""
         mock_get_files.return_value = set()
         mock_get_diff.side_effect = GitError("no changes")
 
-        with pytest.raises(GitError):
-            classify_commit_type(verbose_config)
-
-        mock_debug_header.assert_any_call("Commit Classification Failed")
-        mock_debug_item.assert_any_call("Error Type", "GitError")
+        result = classify_commit_type(verbose_config)
+        assert result == CommitType.CHORE
+        mock_debug_header.assert_any_call("No Specific Pattern Matched")
+        mock_debug_item.assert_any_call("Default Type", "CHORE")
 
     @patch("git_acp.git.classification.get_changed_files")
     @patch("git_acp.git.classification.get_diff")


### PR DESCRIPTION
### Motivation
- Prevent duplicate or conflicting commit type prefixes when AI-generated messages already include a conventional prefix. 
- Ensure AI produces title-first output without a type prefix so the workflow can apply a single canonical `CommitType`. 
- Make commit classification and formatting robust to AI-provided prefixes and emoji annotations.

### Description
- Add `strip_conventional_prefix` helper to `git_acp.git.classification` to remove `type`, `type(scope)`, `type emoji`, and `type(scope) emoji` style prefixes from titles. 
- Export `strip_conventional_prefix` from `git_acp.git.__init__` and use it in `GitWorkflow._format_message` to normalize AI-provided titles before applying the selected `CommitType`. 
- Update AI prompt templates in `git_acp/ai/ai_utils.py` to instruct models not to include a conventional commit type prefix in the title. 
- Add and update unit tests covering prefix stripping and workflow formatting in `tests/git/test_classification.py`, `tests/cli/test_workflow.py`, and `tests/ai/test_ai_utils.py`, and update `project-overview.md` to reflect the behavior change.

### Testing
- Ran unit tests for the modified areas including `tests/git/test_classification.py`, `tests/cli/test_workflow.py`, and `tests/ai/test_ai_utils.py`. All tests passed.
- Existing AI prompt and formatting tests were updated and verified to succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0642fad088832b818d5a70b4fc160b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Commit message suggestions and formatting now normalize subjects by removing conventional commit-type prefixes for cleaner titles.

* **Bug Fixes**
  * Improved change detection when no staged changes: message generation and type classification now consider selected files and untracked new files so AI suggestions are more accurate; falls back to a default type when diffs are unavailable.

* **Tests**
  * Expanded tests covering prefix handling and message normalization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/beecave-homelab/git-acp/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->