### PR TITLE
feat: add --setup flag to automate initial config creation

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -143,13 +143,29 @@ git-acp -o --test-ai
 
 ## Configuration
 
-### Create Configuration Directory
+### Quick Setup (Recommended)
+
+After installing, run the built-in setup command to create your configuration file:
+
+```bash
+git-acp --setup
+```
+
+This copies the default configuration template to `~/.config/git-acp/.env`. Edit the file to customize your settings. To overwrite an existing config:
+
+```bash
+git-acp --setup --force
+```
+
+### Manual Setup
+
+#### Create Configuration Directory
 
 ```bash
 mkdir -p ~/.config/git-acp
 ```
 
-### Set Up Environment
+#### Set Up Environment
 
 Create `~/.config/git-acp/.env`:
 

--- a/docs/getting_started/quick_start.md
+++ b/docs/getting_started/quick_start.md
@@ -24,6 +24,14 @@
     pipx install "git+https://github.com/beecave-homelab/git-acp.git"
     ```
 
+3. Run the setup command to create your initial configuration:
+
+    ```bash
+    git-acp --setup
+    ```
+
+   This creates `~/.config/git-acp/.env` with default settings. Edit it to customize your configuration.
+
 ### Alternative: Install with pip
 
 To install the `git_acp` package using pip:

--- a/git_acp/.env.example
+++ b/git_acp/.env.example
@@ -1,0 +1,72 @@
+# AI CONFIGURATION
+# Model name for Ollama (default is mevatron/diffsense:1.5b)
+GIT_ACP_AI_MODEL=mevatron/diffsense:1.5b
+
+# Temperature for AI generation (0.0 to 1.0, higher = more creative)
+GIT_ACP_TEMPERATURE=0.3
+
+# Ollama API endpoint (use localhost if running locally)
+GIT_ACP_BASE_URL=http://localhost:11434/v1
+
+# Fallback Ollama API endpoint when local server is unavailable
+GIT_ACP_FALLBACK_BASE_URL=https://diffsense.onrender.com/v1
+
+# API key for Ollama (default is "ollama")
+GIT_ACP_API_KEY=ollama
+
+# Prompt type for commit message generation ("simple" or "advanced")
+GIT_ACP_PROMPT_TYPE=simple
+
+# Timeout for AI requests in seconds (default is 120.0)
+GIT_ACP_AI_TIMEOUT=120.0
+
+# Context window size in tokens for Ollama requests (default is 8192)
+GIT_ACP_CONTEXT_WINDOW=8192
+
+# GIT CONFIGURATION
+# Default branch name for push operations
+GIT_ACP_DEFAULT_BRANCH=main
+
+# Default remote name
+GIT_ACP_DEFAULT_REMOTE=origin
+
+# Number of commits to analyze for context
+GIT_ACP_NUM_RECENT_COMMITS=3
+GIT_ACP_NUM_RELATED_COMMITS=3
+
+# Maximum number of diff lines to preview
+GIT_ACP_MAX_DIFF_PREVIEW_LINES=10
+
+# Max number of non-type groups to create when auto-grouping changes
+GIT_ACP_AUTO_GROUP_MAX_NON_TYPE_GROUPS=5
+
+# TERMINAL CONFIGURATION
+# Terminal Colors (supports rich color names)
+GIT_ACP_DEBUG_HEADER_COLOR=blue
+GIT_ACP_DEBUG_VALUE_COLOR=cyan
+GIT_ACP_SUCCESS_COLOR=green
+GIT_ACP_WARNING_COLOR=yellow
+GIT_ACP_STATUS_COLOR=bold green
+GIT_ACP_ERROR_COLOR=bold red
+GIT_ACP_AI_MESSAGE_HEADER_COLOR=bold yellow
+GIT_ACP_AI_MESSAGE_BORDER_COLOR=yellow
+GIT_ACP_KEY_COMBINATION_COLOR=cyan
+GIT_ACP_INSTRUCTION_TEXT_COLOR=dim
+GIT_ACP_BOLD_COLOR=dim
+
+# Maximum length of debug values before truncation
+GIT_ACP_MAX_DEBUG_VALUE_CHARS=1200
+
+# Maximum width for formatted output (in characters)
+GIT_ACP_TERMINAL_WIDTH=100
+
+# COMMIT TYPES CONFIGURATION
+# Customize commit types and their emojis
+GIT_ACP_COMMIT_TYPE_FEAT="feat ✨"
+GIT_ACP_COMMIT_TYPE_FIX="fix 🐛"
+GIT_ACP_COMMIT_TYPE_DOCS="docs 📝"
+GIT_ACP_COMMIT_TYPE_STYLE="style 💎"
+GIT_ACP_COMMIT_TYPE_REFACTOR="refactor ♻️"
+GIT_ACP_COMMIT_TYPE_TEST="test 🧪"
+GIT_ACP_COMMIT_TYPE_CHORE="chore 📦"
+GIT_ACP_COMMIT_TYPE_REVERT="revert ⏪"

--- a/git_acp/.env.example
+++ b/git_acp/.env.example
@@ -23,6 +23,15 @@ GIT_ACP_AI_TIMEOUT=120.0
 # Context window size in tokens for Ollama requests (default is 8192)
 GIT_ACP_CONTEXT_WINDOW=8192
 
+# Ratio of context window used for simple prompts (default is 0.65)
+GIT_ACP_SIMPLE_CONTEXT_RATIO=0.65
+
+# Ratio of context window used for advanced prompts (default is 0.80)
+GIT_ACP_ADVANCED_CONTEXT_RATIO=0.80
+
+# Minimum tokens reserved for staged changes (default is 2000)
+GIT_ACP_MIN_CHANGES_CONTEXT=2000
+
 # GIT CONFIGURATION
 # Default branch name for push operations
 GIT_ACP_DEFAULT_BRANCH=main
@@ -44,6 +53,7 @@ GIT_ACP_AUTO_GROUP_MAX_NON_TYPE_GROUPS=5
 # Terminal Colors (supports rich color names)
 GIT_ACP_DEBUG_HEADER_COLOR=blue
 GIT_ACP_DEBUG_VALUE_COLOR=cyan
+GIT_ACP_INFO_COLOR=cyan
 GIT_ACP_SUCCESS_COLOR=green
 GIT_ACP_WARNING_COLOR=yellow
 GIT_ACP_STATUS_COLOR=bold green

--- a/git_acp/cli/cli.py
+++ b/git_acp/cli/cli.py
@@ -254,6 +254,20 @@ def _process_add_argument(add: str | None) -> tuple[str | None, bool]:
     default=False,
     help="Automatically group related changes into multiple focused commits",
 )
+@click.option(
+    "--setup",
+    "run_setup_flag",
+    is_flag=True,
+    help=(
+        "Run initial configuration setup. Copies .env.example to "
+        "~/.config/git-acp/.env. Use with --force to overwrite existing config."
+    ),
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    help="Used with --setup to overwrite an existing configuration file.",
+)
 def main(
     add: str | None,
     message: str | None,
@@ -269,6 +283,8 @@ def main(
     context_window: int | None,
     dry_run: bool,
     auto_group: bool,
+    run_setup_flag: bool,
+    force: bool,
 ) -> None:
     """Automate git add, commit, and push operations with smart features.
 
@@ -291,6 +307,11 @@ def main(
     - General: Program behavior control (-nc, -v)
     """  # noqa: D301
     setup_signal_handlers()
+
+    if run_setup_flag:
+        from git_acp.config.env_config import run_setup
+
+        sys.exit(run_setup(force=force))
 
     try:
         # Process -a argument (glob expansion)

--- a/git_acp/cli/cli.py
+++ b/git_acp/cli/cli.py
@@ -309,7 +309,7 @@ def main(
     setup_signal_handlers()
 
     if run_setup_flag:
-        from git_acp.config.env_config import run_setup
+        from git_acp.config import run_setup
 
         sys.exit(run_setup(force=force))
 

--- a/git_acp/config/__init__.py
+++ b/git_acp/config/__init__.py
@@ -28,7 +28,7 @@ from git_acp.config.constants import (
     USER_CONFIG_DIR,
     USER_ENV_FILE,
 )
-from git_acp.config.env_config import get_env, load_env_config
+from git_acp.config.env_config import get_env, load_env_config, run_setup
 
 __all__ = [
     "ADVANCED_PROMPT_CONTEXT_RATIO",
@@ -59,4 +59,5 @@ __all__ = [
     "USER_ENV_FILE",
     "get_env",
     "load_env_config",
+    "run_setup",
 ]

--- a/git_acp/config/env_config.py
+++ b/git_acp/config/env_config.py
@@ -65,3 +65,55 @@ def get_env(key: str, default: Any = None, type_cast: type | None = None) -> Any
             return default
 
     return value
+
+
+def run_setup(*, force: bool = False) -> int:
+    """Run initial config setup by copying .env.example to user config dir.
+
+    Uses importlib.resources to locate the bundled .env.example from the
+    installed package, making it work regardless of installation method
+    (pipx, pip, pdm, etc.).
+
+    Args:
+        force: If True, overwrite existing config file without prompting.
+
+    Returns:
+        Exit code: 0 on success, 1 on failure.
+    """
+    import importlib.resources as pkg_resources
+
+    config_dir = get_config_dir()
+    env_file = config_dir / ".env"
+
+    # Locate the bundled .env.example
+    try:
+        # Python 3.10+: as_file + files
+        ref = pkg_resources.files("git_acp") / ".env.example"
+        with pkg_resources.as_file(ref) as example_path:
+            if not example_path.exists():
+                print("❌ ERROR: .env.example not found in package installation.")
+                return 1
+            source_content = example_path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"❌ ERROR: Could not locate .env.example in package: {e}")
+        return 1
+
+    # Check if user config already exists
+    if env_file.exists() and not force:
+        print(f"⚠️  Configuration file already exists at: {env_file}")
+        print("   Use --setup --force to overwrite, or edit the file directly.")
+        return 0
+
+    # Create config dir and write file
+    try:
+        ensure_config_dir()
+        env_file.write_text(source_content, encoding="utf-8")
+        print(f"✅ Configuration file created at: {env_file}")
+        print("\nEdit this file to customize your settings:")
+        print("  - GIT_ACP_BASE_URL (OpenAI-compatible endpoint)")
+        print("  - GIT_ACP_API_KEY (API key, if required)")
+        print("  - GIT_ACP_AI_MODEL (model name)")
+        return 0
+    except OSError as e:
+        print(f"❌ ERROR: Failed to write configuration: {e}")
+        return 1

--- a/scripts/setup-config.py
+++ b/scripts/setup-config.py
@@ -11,7 +11,7 @@ import sys
 def main() -> None:
     """Run setup via the shared config module."""
     try:
-        from git_acp.config.env_config import run_setup
+        from git_acp.config import run_setup
 
         sys.exit(run_setup(force=False))
     except ImportError as e:

--- a/scripts/setup-config.py
+++ b/scripts/setup-config.py
@@ -1,71 +1,23 @@
 #!/usr/bin/env python
 """User configuration setup script for git-acp.
 
-This script copies the .env.example file to the user's configuration
-directory to help them get started with custom settings.
-It's designed to be run both directly and via PDM.
+Thin wrapper around the shared run_setup() function.
+Can be run directly or via PDM: pdm run setup-config
 """
 
-import shutil
 import sys
-from pathlib import Path
-
-# --- Add project root to Python path ---
-# This allows the script to import modules from the main application package,
-# ensuring it works correctly when run directly or via PDM.
-try:
-    # Assumes the script is in the 'scripts' directory, one level below project root
-    _project_root = Path(__file__).resolve().parent.parent
-    sys.path.insert(0, str(_project_root))
-
-    from git_acp.config.constants import (
-        USER_CONFIG_DIR,
-        USER_ENV_FILE,
-    )
-except ImportError as e:
-    print(f"❌ Error: Failed to import project constants. {e}")
-    print("Please ensure you are running this script from the project root,")
-    print("or that the 'git_acp' package is in your PYTHONPATH.")
-    sys.exit(1)
-
-
-# The source template is always located at the project root.
-SOURCE_ENV_FILE = _project_root / ".env.example"
 
 
 def main() -> None:
-    """Manage the creation/update of the user-specific .env file."""
-    print(f"🔧 Attempting to set up user configuration at: {USER_ENV_FILE}")
-
-    if not SOURCE_ENV_FILE.exists():
-        print(f"❌ ERROR: Source file '{SOURCE_ENV_FILE}' not found.")
-        print("Please ensure '.env.example' exists in the project root.")
-        return
-
-    if USER_ENV_FILE.exists():
-        print(f"⚠️ User configuration file already exists at '{USER_ENV_FILE}'.")
-        try:
-            overwrite_choice = (
-                input("Do you want to overwrite it? (yes/no) [no]: ").strip().lower()
-            )
-        except (EOFError, KeyboardInterrupt):
-            print("\nOperation cancelled by user.")
-            return
-
-        if overwrite_choice not in ["yes", "y"]:
-            print("Exiting without overwriting. Your existing configuration is safe.")
-            return
-        print("Proceeding to overwrite existing configuration...")
-
+    """Run setup via the shared config module."""
     try:
-        USER_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(SOURCE_ENV_FILE, USER_ENV_FILE)
-        print(f"\n✅ Successfully copied '{SOURCE_ENV_FILE}' to '{USER_ENV_FILE}'.")
-        print("\nPlease edit this file to add your specific configurations, such as:")
-        print("  - GIT_ACP_BASE_URL (OpenAI-compatible endpoint)")
-        print("  - GIT_ACP_API_KEY (API key for your backend, if required)")
-    except Exception as e:
-        print(f"\n❌ An error occurred during setup: {e}")
+        from git_acp.config.env_config import run_setup
+
+        sys.exit(run_setup(force=False))
+    except ImportError as e:
+        print(f"❌ Error: Failed to import git_acp: {e}")
+        print("Please ensure git-acp is installed.")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -132,6 +132,20 @@ class TestCli(unittest.TestCase):
         self.assertIn("git-acp, version", result.output)
         self.assertIn(__version__, result.output)
 
+    @patch("git_acp.config.env_config.run_setup", return_value=0)
+    def test_cli_setup_flag(self, mock_setup: MagicMock) -> None:
+        """Should call run_setup when --setup is passed."""
+        result = self.runner.invoke(main, ["--setup"])
+        assert result.exit_code == 0
+        mock_setup.assert_called_once_with(force=False)
+
+    @patch("git_acp.config.env_config.run_setup", return_value=0)
+    def test_cli_setup_with_force(self, mock_setup: MagicMock) -> None:
+        """Should call run_setup with force=True when both flags passed."""
+        result = self.runner.invoke(main, ["--setup", "--force"])
+        assert result.exit_code == 0
+        mock_setup.assert_called_once_with(force=True)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -132,14 +132,14 @@ class TestCli(unittest.TestCase):
         self.assertIn("git-acp, version", result.output)
         self.assertIn(__version__, result.output)
 
-    @patch("git_acp.config.env_config.run_setup", return_value=0)
+    @patch("git_acp.config.run_setup", return_value=0)
     def test_cli_setup_flag(self, mock_setup: MagicMock) -> None:
         """Should call run_setup when --setup is passed."""
         result = self.runner.invoke(main, ["--setup"])
         assert result.exit_code == 0
         mock_setup.assert_called_once_with(force=False)
 
-    @patch("git_acp.config.env_config.run_setup", return_value=0)
+    @patch("git_acp.config.run_setup", return_value=0)
     def test_cli_setup_with_force(self, mock_setup: MagicMock) -> None:
         """Should call run_setup with force=True when both flags passed."""
         result = self.runner.invoke(main, ["--setup", "--force"])

--- a/tests/config/test_env_config.py
+++ b/tests/config/test_env_config.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -11,6 +11,7 @@ from git_acp.config.env_config import (
     get_config_dir,
     get_env,
     load_env_config,
+    run_setup,
 )
 
 
@@ -77,3 +78,92 @@ class TestEnvConfig:
             assert get_env("TEST_BOOL", val, bool) is True
         for val in ["0", "no", "n", "false"]:
             assert get_env("TEST_BOOL", val, bool) is False
+
+
+class TestRunSetup:
+    """Test suite for the run_setup function."""
+
+    def test_creates_config_when_none_exists(self, tmp_path):
+        """Should create config file from bundled .env.example."""
+        config_dir = tmp_path / ".config" / "git-acp"
+        env_file = config_dir / ".env"
+
+        mock_example = MagicMock()
+        mock_example.exists.return_value = True
+        mock_example.read_text.return_value = "GIT_ACP_AI_MODEL=test\n"
+
+        mock_ref = MagicMock()
+        mock_ref.__truediv__ = lambda s, o: mock_example
+
+        with (
+            patch("git_acp.config.env_config.get_config_dir", return_value=config_dir),
+            patch("importlib.resources.files", return_value=mock_ref),
+            patch("importlib.resources.as_file") as mock_as_file,
+        ):
+            mock_as_file.return_value.__enter__ = lambda s: mock_example
+            mock_as_file.return_value.__exit__ = MagicMock(return_value=False)
+            result = run_setup()
+
+        assert result == 0
+        assert env_file.exists()
+        assert env_file.read_text(encoding="utf-8") == "GIT_ACP_AI_MODEL=test\n"
+
+    def test_skips_when_config_exists_no_force(self, tmp_path):
+        """Should not overwrite existing config without force."""
+        config_dir = tmp_path / ".config" / "git-acp"
+        config_dir.mkdir(parents=True)
+        env_file = config_dir / ".env"
+        env_file.write_text("existing content", encoding="utf-8")
+
+        with patch("git_acp.config.env_config.get_config_dir", return_value=config_dir):
+            result = run_setup(force=False)
+
+        assert result == 0
+        assert env_file.read_text(encoding="utf-8") == "existing content"
+
+    def test_overwrites_with_force(self, tmp_path):
+        """Should overwrite existing config when force=True."""
+        config_dir = tmp_path / ".config" / "git-acp"
+        config_dir.mkdir(parents=True)
+        env_file = config_dir / ".env"
+        env_file.write_text("old content", encoding="utf-8")
+
+        mock_example = MagicMock()
+        mock_example.exists.return_value = True
+        mock_example.read_text.return_value = "new content\n"
+
+        mock_ref = MagicMock()
+        mock_ref.__truediv__ = lambda s, o: mock_example
+
+        with (
+            patch("git_acp.config.env_config.get_config_dir", return_value=config_dir),
+            patch("importlib.resources.files", return_value=mock_ref),
+            patch("importlib.resources.as_file") as mock_as_file,
+        ):
+            mock_as_file.return_value.__enter__ = lambda s: mock_example
+            mock_as_file.return_value.__exit__ = MagicMock(return_value=False)
+            result = run_setup(force=True)
+
+        assert result == 0
+        assert env_file.read_text(encoding="utf-8") == "new content\n"
+
+    def test_returns_error_when_example_not_found(self, tmp_path):
+        """Should return error code when .env.example is missing."""
+        config_dir = tmp_path / ".config" / "git-acp"
+
+        mock_example = MagicMock()
+        mock_example.exists.return_value = False
+
+        mock_ref = MagicMock()
+        mock_ref.__truediv__ = lambda s, o: mock_example
+
+        with (
+            patch("git_acp.config.env_config.get_config_dir", return_value=config_dir),
+            patch("importlib.resources.files", return_value=mock_ref),
+            patch("importlib.resources.as_file") as mock_as_file,
+        ):
+            mock_as_file.return_value.__enter__ = lambda s: mock_example
+            mock_as_file.return_value.__exit__ = MagicMock(return_value=False)
+            result = run_setup()
+
+        assert result == 1


### PR DESCRIPTION
## Summary

Adds an optional `--setup` CLI flag that automates initial configuration setup for users who install via `pipx`.

Closes #76

## What it does

`git-acp --setup` copies the bundled `.env.example` to `~/.config/git-acp/.env`, creating the directory if needed. With `--force`, it overwrites an existing config without prompting.

## Changes

- **`git_acp/config/env_config.py`** — new `run_setup()` function using `importlib.resources` to find `.env.example` from the installed package
- **`git_acp/cli/cli.py`** — `--setup` and `--force` flags wired in; `--setup` runs setup and exits immediately
- **`git_acp/.env.example`** — bundled into the package for runtime discovery
- **`scripts/setup-config.py`** — refactored to a thin wrapper around `run_setup()`
- **Tests** — 4 new tests for `run_setup()`, 2 new CLI tests
- **Docs** — installation.md and quick_start.md updated

## Test plan

- [x] 380/380 tests pass
- [x] `ruff` lint + format clean
- [x] `git-acp --setup` creates config from bundled template
- [x] `git-acp --setup --force` overwrites existing config
- [x] `git-acp --setup` prompts when config exists (without `--force`)
- [x] Works after `pipx install` (uses `importlib.resources`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--setup` flag to initialize application configuration
  * Added `--force` flag to overwrite existing configuration files during setup

* **Tests**
  * Added test coverage for setup command with and without force flag

<!-- end of auto-generated comment: release notes by coderabbit.ai -->