### PR TITLE
fix 🐛: enable perf grouping and fix benchmark path pattern matching

### DIFF
--- a/git_acp/config/constants.py
+++ b/git_acp/config/constants.py
@@ -118,9 +118,10 @@ FILE_PATH_PATTERNS: Final[dict[str, list[str]]] = {
         "azure-pipelines.yml",
     ],
     "perf": [
-        "benchmark",
-        "profiling",
-        "performance",
+        "benchmarks/",
+        "benchmark/",
+        "profiling/",
+        "perf/",
     ],
     "chore": [
         ".gitignore",

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -3,6 +3,9 @@
 This module provides functionality for classifying commit types and analyzing
 changes in the repository to suggest appropriate commit types.
 
+Recognized Commit Types:
+    FEAT, FIX, DOCS, STYLE, REFACTOR, TEST, CHORE, REVERT, BUILD, CI, PERF.
+
 Classification Priority:
     1. Message prefix (e.g., "feat:", "fix:") - highest priority
     2. File path patterns - deterministic and highly accurate
@@ -159,7 +162,8 @@ def group_changed_files(
 
     - Files are sorted alphabetically within each returned group.
     - Groups are ordered by:
-        1) Commit-type priority: ``docs``, ``test``, ``style``, ``chore``.
+        1) Commit-type priority: ``docs``, ``test``, ``perf``, ``style``,
+           ``build``, ``ci``, ``chore``.
         2) Directory prefix groups (lexicographic).
         3) Root-level extension groups (lexicographic).
 
@@ -182,7 +186,7 @@ def group_changed_files(
         ``FILE_PATH_PATTERNS`` and ``EXCLUDED_PATTERNS`` come from
         ``git_acp.config.constants``.
     """
-    commit_type_priority = ["docs", "test", "style", "build", "ci", "chore"]
+    commit_type_priority = ["docs", "test", "perf", "style", "build", "ci", "chore"]
 
     def is_excluded(file_path: str) -> bool:
         for pattern in EXCLUDED_PATTERNS:

--- a/tests/git/test_grouping.py
+++ b/tests/git/test_grouping.py
@@ -15,12 +15,18 @@ class TestGroupChangedFiles:
         assert group_changed_files(set()) == []
 
     def test_commit_type_priority_ordering(self) -> None:
-        """Group commit-types first and respect priority ordering."""
+        """Group commit-types first and respect priority ordering.
+
+        Priority order is docs, test, perf, style, build, ci, chore.
+        """
         files = {
             "tests/test_core.py",
             "docs/intro.md",
+            "benchmarks/bench_core.py",
             "pyproject.toml",
             "ruff.toml",
+            "Dockerfile",
+            ".github/workflows/ci.yml",
         }
 
         groups = group_changed_files(files)
@@ -28,9 +34,34 @@ class TestGroupChangedFiles:
         assert groups == [
             ["docs/intro.md"],
             ["tests/test_core.py"],
+            ["benchmarks/bench_core.py"],
             ["ruff.toml"],
+            ["Dockerfile"],
+            [".github/workflows/ci.yml"],
             ["pyproject.toml"],
         ]
+
+    def test_build_files_grouped_as_build(self) -> None:
+        """Build files form a build type group instead of extension groups."""
+        files = {
+            "Dockerfile",
+            "docker-compose.yml",
+        }
+
+        groups = group_changed_files(files)
+
+        assert groups == [["Dockerfile", "docker-compose.yml"]]
+
+    def test_perf_files_grouped_as_perf(self) -> None:
+        """Benchmark and profiling files form a perf type group."""
+        files = {
+            "benchmarks/bench_core.py",
+            "profiling/trace.py",
+        }
+
+        groups = group_changed_files(files)
+
+        assert groups == [["benchmarks/bench_core.py", "profiling/trace.py"]]
 
     def test_files_sorted_within_each_group(self) -> None:
         """Sort files alphabetically within each group."""


### PR DESCRIPTION
## Summary

Fixes two issues with perf file classification (issue #82):

1. **Perf missing from commit_type_priority** — `perf` had `FILE_PATH_PATTERNS` defined in `constants.py` but was not in the `commit_type_priority` list in `group_changed_files()`. This meant benchmark/profiling files were never grouped as a perf type; they fell through to extension-based grouping.

2. **Benchmark path pattern didn't match real projects** — The old patterns (`benchmark`, `profiling`, `performance`) used word-boundary regex (`\bbenchmark\b`), which fails to match the common `benchmarks/` directory (plural). Switched to directory-style patterns: `benchmarks/`, `benchmark/`, `profiling/`, `perf/`.

## Changes

- `git_acp/config/constants.py`: Updated perf `FILE_PATH_PATTERNS` to directory-style patterns
- `git_acp/git/classification.py`: Added `perf` to `commit_type_priority`; updated module and function docstrings to list all recognized types (BUILD, CI, PERF)
- `tests/git/test_grouping.py`: Extended priority ordering test; added dedicated build and perf grouping tests

## Test results

- 423 tests pass (2 new)
- `ruff check`: clean
- `mypy`: clean

Closes #82