### PR TITLE
refactor: PR #83 follow-ups (issue #84) - DRY exclusion, enum-driven CLI, narrowed exceptions

### DIFF
--- a/git_acp/cli/cli.py
+++ b/git_acp/cli/cli.py
@@ -34,6 +34,12 @@ from git_acp.git import (
 from git_acp.utils import GitConfig
 from git_acp.utils.file_filter import filter_files_by_scope
 
+# Single source of truth for the --type CLI option: derived from the
+# CommitType enum so choices and help text can never drift apart.
+CLI_COMMIT_TYPE_CHOICES: tuple[str, ...] = tuple(
+    ct.name.lower() for ct in CommitType
+)
+
 
 def format_commit_message(commit_type: CommitType, message: str) -> str:
     """Format a commit message according to conventional commits specification.
@@ -154,26 +160,10 @@ def _process_add_argument(add: str | None) -> tuple[str | None, bool]:
     "-t",
     "--type",
     "commit_type",
-    type=click.Choice(
-        [
-            "feat",
-            "fix",
-            "docs",
-            "style",
-            "refactor",
-            "test",
-            "chore",
-            "revert",
-            "build",
-            "ci",
-            "perf",
-        ],
-        case_sensitive=False,
-    ),
+    type=click.Choice(CLI_COMMIT_TYPE_CHOICES, case_sensitive=False),
     help=(
         "Manually specify the commit type instead of using automatic detection. "
-        "Supported types: feat, fix, docs, style, refactor, test, chore, revert, "
-        "build, ci, perf."
+        f"Supported types: {', '.join(CLI_COMMIT_TYPE_CHOICES)}."
     ),
     metavar="<type>",
 )

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from git_acp.config import (
     COMMIT_TYPE_PATTERNS,
     COMMIT_TYPES,
-    EXCLUDED_PATTERNS,
     FILE_PATH_PATTERNS,
     SIGNAL_LAYER_WEIGHTS,
 )
@@ -31,6 +30,7 @@ from git_acp.git.file_classifier import (
     _match_file_path_pattern,
     _normalize_path_separators,
     categorize_changed_files,
+    is_file_excluded,
 )
 from git_acp.git.git_operations import GitError, get_changed_files, get_diff
 from git_acp.utils import OptionalConfig, debug_header, debug_item
@@ -184,19 +184,7 @@ def group_changed_files(
     """
     commit_type_priority = ["docs", "test", "style", "build", "ci", "chore"]
 
-    def is_excluded(file_path: str) -> bool:
-        for pattern in EXCLUDED_PATTERNS:
-            # Special case for exact .env matching as defined in EXCLUDED_PATTERNS.
-            # This is hardcoded to match the "/.env$" pattern in constants.py.
-            if pattern == "/.env$":
-                if Path(file_path).name == ".env":
-                    return True
-                continue
-            if pattern in file_path:
-                return True
-        return False
-
-    remaining = sorted({f for f in files if f and not is_excluded(f)})
+    remaining = sorted({f for f in files if f and not is_file_excluded(f)})
     if not remaining:
         return []
 
@@ -567,8 +555,11 @@ def _collect_signals(
     numstat: dict[str, tuple[int, int]] = {}
     try:
         numstat = get_numstat(config)
-    except (GitError, Exception):
-        pass
+    except GitError:
+        pass  # expected: no staged/unstaged changes
+    except Exception as err:
+        if config.verbose:
+            debug_item("Numstat unexpected error", str(err))
 
     if config.verbose and numstat:
         debug_item("Numstat files", str(len(numstat)))

--- a/git_acp/git/diff.py
+++ b/git_acp/git/diff.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from git_acp.config import EXCLUDED_PATTERNS
 from git_acp.utils import DiffType, OptionalConfig, debug_header, debug_item
 
 from .core import GitError, run_git_command
+from .file_classifier import is_file_excluded
 
 # Default line count assigned to binary files in numstat output
 # (shown as "-" in git diff --numstat).
@@ -63,28 +61,10 @@ def get_changed_files(
                 files.add(path)
 
     if files:
-        excluded_files = set()
-        for f in files:
-            for pattern in EXCLUDED_PATTERNS:
-                if pattern == "/.env$":
-                    if Path(f).name == ".env":
-                        if config and config.verbose:
-                            debug_item(
-                                "Excluding file based on pattern",
-                                f"Pattern '{pattern}' matched '{f}'",
-                            )
-                        excluded_files.add(f)
-                        break
-                    continue
-
-                if pattern in f:
-                    if config and config.verbose:
-                        debug_item(
-                            "Excluding file based on pattern",
-                            f"Pattern '{pattern}' matched '{f}'",
-                        )
-                    excluded_files.add(f)
-                    break
+        excluded_files = {f for f in files if is_file_excluded(f)}
+        for f in excluded_files:
+            if config and config.verbose:
+                debug_item("Excluding file", f)
         files -= excluded_files
 
     if config and config.verbose:
@@ -179,16 +159,7 @@ def get_numstat(config: OptionalConfig = None) -> dict[str, tuple[int, int]]:
         added = _BINARY_LINE_COUNT if added_str == "-" else int(added_str)
         removed = 0 if removed_str == "-" else int(removed_str)
 
-        # Apply exclusion filter
-        excluded = False
-        for pattern in EXCLUDED_PATTERNS:
-            if pattern == "/.env$" and Path(filepath).name == ".env":
-                excluded = True
-                break
-            if pattern in filepath:
-                excluded = True
-                break
-        if excluded:
+        if is_file_excluded(filepath):
             continue
 
         result[filepath] = (added, removed)

--- a/git_acp/git/file_classifier.py
+++ b/git_acp/git/file_classifier.py
@@ -86,6 +86,9 @@ def is_file_excluded(file_path: str) -> bool:
     represents an exact-basename match (``.env`` but not
     ``.env.example``) that cannot be expressed as a literal substring.
 
+    Args:
+        file_path: Repository-relative file path to check.
+
     Returns:
         ``True`` if the file path matches any exclusion pattern.
     """

--- a/git_acp/git/file_classifier.py
+++ b/git_acp/git/file_classifier.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import re
 from enum import Enum
+from pathlib import Path
 
-from git_acp.config import FILE_CATEGORY_PATTERNS
+from git_acp.config import EXCLUDED_PATTERNS, FILE_CATEGORY_PATTERNS
 
 
 class FileCategory(Enum):
@@ -74,6 +75,28 @@ def _match_file_path_pattern(file_path: str, pattern: str) -> bool:
         return any(seg.endswith(pattern_lower) for seg in file_segments)
 
     return any(pattern_lower in seg for seg in file_segments)
+
+
+def is_file_excluded(file_path: str) -> bool:
+    """Check whether *file_path* matches any ``EXCLUDED_PATTERNS`` entry.
+
+    Uses :func:`_match_file_path_pattern` for consistent segment-aware
+    matching, the same matcher used by file-category and commit-type
+    classification. The ``/.env$`` pattern is special-cased because it
+    represents an exact-basename match (``.env`` but not
+    ``.env.example``) that cannot be expressed as a literal substring.
+
+    Returns:
+        ``True`` if the file path matches any exclusion pattern.
+    """
+    for pattern in EXCLUDED_PATTERNS:
+        if pattern == "/.env$":
+            if Path(file_path).name == ".env":
+                return True
+            continue
+        if _match_file_path_pattern(file_path, pattern):
+            return True
+    return False
 
 
 def classify_file_category(path: str) -> FileCategory:

--- a/git_acp/git/git_operations.py
+++ b/git_acp/git/git_operations.py
@@ -6,11 +6,9 @@ It also implements ``get_changed_files`` directly so that tests can patch the
 ``run_git_command`` symbol in this module and fully control its behavior.
 """
 
-from pathlib import Path
-
-from git_acp.config import EXCLUDED_PATTERNS
 from git_acp.utils import OptionalConfig, debug_header, debug_item
 
+from .file_classifier import is_file_excluded
 from .operations import (
     GitError,
     analyze_commit_patterns,
@@ -86,28 +84,10 @@ def get_changed_files(
                 files.add(path)
 
     if files:
-        excluded_files = set()
-        for f in files:
-            for pattern in EXCLUDED_PATTERNS:
-                if pattern == "/.env$":
-                    if Path(f).name == ".env":
-                        if config and config.verbose:
-                            debug_item(
-                                "Excluding file based on pattern",
-                                f"Pattern '{pattern}' matched '{f}'",
-                            )
-                        excluded_files.add(f)
-                        break
-                    continue
-
-                if pattern in f:
-                    if config and config.verbose:
-                        debug_item(
-                            "Excluding file based on pattern",
-                            f"Pattern '{pattern}' matched '{f}'",
-                        )
-                    excluded_files.add(f)
-                    break
+        excluded_files = {f for f in files if is_file_excluded(f)}
+        for f in excluded_files:
+            if config and config.verbose:
+                debug_item("Excluding file", f)
         files -= excluded_files
 
     if config and config.verbose:
@@ -136,5 +116,4 @@ __all__ = [
     "manage_tags",
     "manage_stash",
     "setup_signal_handlers",
-    "EXCLUDED_PATTERNS",
 ]

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -176,8 +176,8 @@ class TestCli(unittest.TestCase):
         """CLI_COMMIT_TYPE_CHOICES must match CommitType enum members."""
         from git_acp.cli.cli import CLI_COMMIT_TYPE_CHOICES
 
-        enum_types = {ct.name.lower() for ct in CommitType}
-        self.assertEqual(set(CLI_COMMIT_TYPE_CHOICES), enum_types)
+        enum_types = [ct.name.lower() for ct in CommitType]
+        self.assertEqual(list(CLI_COMMIT_TYPE_CHOICES), enum_types)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -172,6 +172,13 @@ class TestCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 2)
         self.assertIn("Invalid value", result.output)
 
+    def test_cli_type_choices_match_committype_enum(self) -> None:
+        """CLI_COMMIT_TYPE_CHOICES must match CommitType enum members."""
+        from git_acp.cli.cli import CLI_COMMIT_TYPE_CHOICES
+
+        enum_types = {ct.name.lower() for ct in CommitType}
+        self.assertEqual(set(CLI_COMMIT_TYPE_CHOICES), enum_types)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -14,7 +14,11 @@ from git_acp.git.classification import (
     strip_conventional_prefix,
 )
 from git_acp.git.diff import extract_added_lines
-from git_acp.git.file_classifier import categorize_changed_files, classify_file_category
+from git_acp.git.file_classifier import (
+    categorize_changed_files,
+    classify_file_category,
+    is_file_excluded,
+)
 from git_acp.git.git_operations import GitError
 
 
@@ -552,6 +556,69 @@ class TestClassifyCommitTypeEdgeCases:
         mock_debug_header.assert_any_call("Commit Classification Result")
         mock_debug_item.assert_any_call("Source", "scoring")
 
+    @patch("git_acp.git.classification.get_numstat")
+    @patch("git_acp.git.classification.get_changed_files")
+    @patch("git_acp.git.classification.get_diff")
+    @patch("git_acp.git.classification.debug_item")
+    def test_numstat__unexpected_error_logged_verbose(
+        self,
+        mock_debug_item,
+        mock_get_diff,
+        mock_get_files,
+        mock_get_numstat,
+        verbose_config,
+    ):
+        """Unexpected numstat errors are logged, not silently swallowed."""
+        mock_get_files.return_value = set()
+        mock_get_diff.return_value = "minor change"
+        mock_get_numstat.side_effect = RuntimeError("numstat blew up")
+
+        result = classify_commit_type(verbose_config)
+
+        # Classification should still succeed (CHORE default)
+        assert result == CommitType.CHORE
+        # The unexpected error should have been logged
+        mock_debug_item.assert_any_call(
+            "Numstat unexpected error", "numstat blew up"
+        )
+
+    @patch("git_acp.git.classification.get_numstat")
+    @patch("git_acp.git.classification.get_changed_files")
+    @patch("git_acp.git.classification.get_diff")
+    def test_numstat__unexpected_error_silent_non_verbose(
+        self,
+        mock_get_diff,
+        mock_get_files,
+        mock_get_numstat,
+        mock_config,
+    ):
+        """Unexpected numstat errors are silently absorbed in non-verbose mode."""
+        mock_get_files.return_value = set()
+        mock_get_diff.return_value = "minor change"
+        mock_get_numstat.side_effect = ValueError("corrupt numstat")
+
+        # Should not raise — classification proceeds with empty numstat
+        result = classify_commit_type(mock_config)
+        assert result == CommitType.CHORE
+
+    @patch("git_acp.git.classification.get_numstat")
+    @patch("git_acp.git.classification.get_changed_files")
+    @patch("git_acp.git.classification.get_diff")
+    def test_numstat__git_error_always_silent(
+        self,
+        mock_get_diff,
+        mock_get_files,
+        mock_get_numstat,
+        verbose_config,
+    ):
+        """GitError from numstat is expected (no changes), always silent."""
+        mock_get_files.return_value = set()
+        mock_get_diff.return_value = "minor change"
+        mock_get_numstat.side_effect = GitError("no staged changes")
+
+        result = classify_commit_type(verbose_config)
+        assert result == CommitType.CHORE
+
 
 class TestStripConventionalPrefix:
     """Tests for stripping conventional prefixes from commit titles."""
@@ -703,6 +770,39 @@ class TestFileClassifier:
         assert FileCategory.DEPENDENCY in result
         assert "src/main.py" in result[FileCategory.PRODUCTION]
         assert "tests/test_main.py" in result[FileCategory.TEST]
+
+
+class TestIsFileExcluded:
+    """Tests for is_file_excluded — shared exclusion logic."""
+
+    def test_excludes_env_file(self) -> None:
+        """Exact .env basename is excluded."""
+        assert is_file_excluded(".env")
+        assert is_file_excluded("config/.env")
+
+    def test_does_not_exclude_env_example(self) -> None:
+        """.env.example should not be excluded (only exact .env match)."""
+        assert not is_file_excluded(".env.example")
+        assert not is_file_excluded("config/.env.local")
+
+    def test_excludes_pycache(self) -> None:
+        """__pycache__ paths matching EXCLUDED_PATTERNS are excluded."""
+        assert is_file_excluded("__pycache__/module.cpython-311.pyc")
+
+    def test_excludes_node_modules(self) -> None:
+        """node_modules paths are excluded."""
+        assert is_file_excluded("node_modules/react/index.js")
+
+    def test_does_not_exclude_source_file(self) -> None:
+        """Regular source files are not excluded."""
+        assert not is_file_excluded("src/main.py")
+        assert not is_file_excluded("git_acp/cli/cli.py")
+
+    def test_segment_aware_matching(self) -> None:
+        """Pattern matches on path segments, not arbitrary substrings."""
+        # 'lock' as a substring exists in 'deadlock.py', but segment-aware
+        # matching should not flag it because 'lock' is not a full segment.
+        assert not is_file_excluded("src/deadlock.py")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -775,30 +775,30 @@ class TestFileClassifier:
 class TestIsFileExcluded:
     """Tests for is_file_excluded — shared exclusion logic."""
 
-    def test_excludes_env_file(self) -> None:
+    def test_is_file_excluded__excludes_env_file(self) -> None:
         """Exact .env basename is excluded."""
         assert is_file_excluded(".env")
         assert is_file_excluded("config/.env")
 
-    def test_does_not_exclude_env_example(self) -> None:
+    def test_is_file_excluded__does_not_exclude_env_example(self) -> None:
         """.env.example should not be excluded (only exact .env match)."""
         assert not is_file_excluded(".env.example")
         assert not is_file_excluded("config/.env.local")
 
-    def test_excludes_pycache(self) -> None:
+    def test_is_file_excluded__excludes_pycache(self) -> None:
         """__pycache__ paths matching EXCLUDED_PATTERNS are excluded."""
         assert is_file_excluded("__pycache__/module.cpython-311.pyc")
 
-    def test_excludes_node_modules(self) -> None:
+    def test_is_file_excluded__excludes_node_modules(self) -> None:
         """node_modules paths are excluded."""
         assert is_file_excluded("node_modules/react/index.js")
 
-    def test_does_not_exclude_source_file(self) -> None:
+    def test_is_file_excluded__does_not_exclude_source_file(self) -> None:
         """Regular source files are not excluded."""
         assert not is_file_excluded("src/main.py")
         assert not is_file_excluded("git_acp/cli/cli.py")
 
-    def test_segment_aware_matching(self) -> None:
+    def test_is_file_excluded__segment_aware_matching(self) -> None:
         """Pattern matches on path segments, not arbitrary substrings."""
         # 'lock' as a substring exists in 'deadlock.py', but segment-aware
         # matching should not flag it because 'lock' is not a full segment.


### PR DESCRIPTION
## Summary

Addresses all three items from issue #84 (follow-ups from PR #83 review).

Closes #84

## Changes

### S1: Narrowed exception swallowing in signal collection
`git_acp/git/classification.py:556-562`

`except (GitError, Exception): pass` was silently absorbing programming errors. Split into `except GitError` (expected, no staged changes) and `except Exception` which now logs the error in verbose mode.

### S2: DRY exclusion logic via shared `is_file_excluded()`
`git_acp/git/file_classifier.py:80-98` (new function)

Extracted the exclusion logic (previously duplicated in four places: `diff.py:get_changed_files`, `diff.py:get_numstat`, `classification.py:group_changed_files`, and `git_operations.py:get_changed_files`) into a single `is_file_excluded()` function that uses `_match_file_path_pattern` for consistent segment-aware matching. All four call sites now use the same matcher, eliminating substring-vs-segment-aware inconsistencies in the classification pipeline.

### S3: Single source of truth for `--type` CLI choices
`git_acp/cli/cli.py:36-40, 163-169`

`CLI_COMMIT_TYPE_CHOICES` is derived from the `CommitType` enum at module load time, replacing the hardcoded list in both `click.Choice([...])` and the `help=` string.

## Testing

- 431 tests pass (10 new tests added)
- ruff: clean
- mypy: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized file exclusion logic for consistency across modules.
  * Updated commit type validation to derive from the enum dynamically instead of hardcoded lists.
  * Improved error handling and logging for edge cases in diff processing.

* **Tests**
  * Added test coverage for commit type consistency and file exclusion rules.
  * Enhanced error handling validation in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->