### PR TITLE
fix 🐛: Abort auto-group after cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,7 +94,9 @@
 **/*$py.class
 **/*.so
 **/.Python
-# **/build/
+**/build/
+!test-scenarios/**/build/
+!test-scenarios/**/build/**
 **/develop-eggs/
 **/dist/
 **/downloads/
@@ -127,4 +129,3 @@ ENV/
 # OS specific files
 .DS_Store
 Thumbs.db
-

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@
 !project-overview.md
 !refactor-summary.md
 !VERSIONS.md
+!test-scenarios/
+!test-scenarios/**/
+!test-scenarios/**/*
 !to-do/
 !to-do/*.md
 !AGENTS.md
@@ -91,7 +94,7 @@
 **/*$py.class
 **/*.so
 **/.Python
-**/build/
+# **/build/
 **/develop-eggs/
 **/dist/
 **/downloads/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Python tool to automate Git add, commit, and push actions with optional AI-gen
 ![GIT-ACP logo](./assets/logo/git-acp-logo-textonly.png)
 
 ![Python](https://img.shields.io/badge/python-3.10%2B-blue)
-![Version](https://img.shields.io/badge/version-0.26.0-brightgreen)
+![Version](https://img.shields.io/badge/version-0.27.0-brightgreen)
 ![License](https://img.shields.io/badge/license-MIT-green)
 
 ## Table of Contents

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -2,7 +2,8 @@
 
 ## Table of Contents
 
-- [v0.26.0 (Current) - 07-06-2026](#v0260-current---07-06-2026)
+- [v0.27.0 (Current) - 24-06-2026](#v0270-current---24-06-2026)
+- [v0.26.0 - 07-06-2026](#v0260---07-06-2026)
 - [v0.25.0 - 04-06-2026](#v0250---04-06-2026)
 - [v0.24.0 - 24-05-2026](#v0240---24-05-2026)
 - [v0.23.0 - 27-01-2026](#v0230---27-01-2026)
@@ -36,7 +37,40 @@
 - [v0.6.0 - 21-12-2024](#v060---21-12-2024)
 - [v0.5.0 - 20-12-2024](#v050---20-12-2024)
 
-## v0.26.0 (Current) - *07-06-2026*
+## v0.27.0 (Current) - *24-06-2026*
+
+### 🐛 **Harden auto-group cancellation and classification follow-ups**
+
+### 🐛 Bug Fixes in v0.27.0
+
+- **Fixed**: Auto-group mode now stops processing remaining groups when the user cancels a prompt.
+- **Fixed**: Cancellation now unstages files staged for the cancelled group before exiting.
+- **Fixed**: User cancellation uses exit code `130`, avoiding Click usage-error exit code `2`.
+- **Fixed**: Git index-lock failures now produce a targeted recovery message instead of a generic Git command error.
+- **Fixed**: Performance files under `benchmarks/`, `benchmark/`, `profiling/`, and `perf/` now group as `perf` changes.
+
+### 🔧 Improvements in v0.27.0
+
+- **Added**: `CancelledByUserError` for typed cancellation handling instead of message-string matching.
+- **Refactored**: Shared excluded-file matching through `is_file_excluded()` for diff, numstat, grouping, and git operations.
+- **Updated**: CLI `--type` choices derive from the `CommitType` enum to prevent drift.
+- **Updated**: `.gitignore` to keep general build directories ignored while allowing `test-scenarios/**/build/`.
+- **Updated**: Documentation for cancellation exit code semantics.
+
+### 🧪 Testing improvements in v0.27.0
+
+- **Added**: Auto-group tests for immediate cancellation and cancellation after successful groups.
+- **Added**: Workflow tests for cancellation during file selection, manual message prompts, AI fallback prompts, commit type selection, and confirmation.
+- **Added**: Git core test coverage for index-lock error mapping.
+- **Added**: Exclusion and grouping regression tests for `.env`, `node_modules`, build, and performance files.
+
+### 📝 Key Commits in v0.27.0
+
+`a9d255d`, `52cac44`, `f192cd8`, `63ca0ea`, `ff800a3`, `2bda044`, `fdfec91`, `0882051`, `d91c88e`, `80c22eb`, `3d7f34e`
+
+---
+
+## v0.26.0 - *07-06-2026*
 
 ### ✨ **Add weighted scoring classifier and expanded commit type detection**
 

--- a/docs/api/overview.md
+++ b/docs/api/overview.md
@@ -92,7 +92,7 @@ This is the root of the package and defines the package’s version.
 ```python
 import git_acp
 
-print(git_acp.__version__)  # "0.26.0"
+print(git_acp.__version__)  # "0.27.0"
 ```
 
 ---

--- a/docs/usage/advanced_usage.md
+++ b/docs/usage/advanced_usage.md
@@ -302,7 +302,7 @@ git-acp -nc -mb "CI: Update dependencies" -t chore
 #### Version Bumping
 
 ```bash
-git-acp -a "pyproject.toml git_acp/__init__.py VERSIONS.md" -mb "chore(release): bump version to v0.26.0" -t chore
+git-acp -a "pyproject.toml git_acp/__init__.py VERSIONS.md" -mb "chore(release): bump version to v0.27.0" -t chore
 ```
 
 ### Batch Operations

--- a/docs/usage/basic_usage.md
+++ b/docs/usage/basic_usage.md
@@ -185,6 +185,12 @@ The tool provides clear error messages for common issues:
 - Permission issues
 - Remote access errors
 
+### Exit Codes
+
+- `0`: Workflow completed successfully or there was nothing to commit
+- `1`: Workflow failed
+- `130`: User cancelled an interactive prompt or declined confirmation
+
 ## Getting Help
 
 For command help and options:

--- a/git_acp/__init__.py
+++ b/git_acp/__init__.py
@@ -7,4 +7,4 @@ A command-line tool for automating Git operations with enhanced features:
 - Conventional commits support
 """
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"

--- a/git_acp/cli/cli.py
+++ b/git_acp/cli/cli.py
@@ -22,7 +22,7 @@ from rich.panel import Panel
 
 from git_acp import __version__
 from git_acp.cli.interaction import RichQuestionaryInteraction
-from git_acp.cli.workflow import GitWorkflow
+from git_acp.cli.workflow import EXIT_CODE_CANCELLED, GitWorkflow
 from git_acp.config import COLORS, DEFAULT_AUTO_GROUP_MAX_NON_TYPE_GROUPS
 from git_acp.git import (
     CommitType,
@@ -383,6 +383,7 @@ def main(
 
             success_count = 0
             failure_count = 0
+            cancelled_at_group: int | None = None
 
             for index, group in enumerate(groups, start=1):
                 staged_before = get_changed_files(config, staged_only=True)
@@ -420,6 +421,9 @@ def main(
                     exit_code = workflow.run()
                     if exit_code == 0:
                         success_count += 1
+                    elif exit_code == EXIT_CODE_CANCELLED:
+                        cancelled_at_group = index
+                        break
                     else:
                         failure_count += 1
                 except Exception as e:  # noqa: BLE001
@@ -433,19 +437,31 @@ def main(
                         )
                     )
                 finally:
+                    # Defensive cleanup in case a workflow exits before its
+                    # handler-level cleanup runs.
                     unstage_files(config)
 
-            border = "green" if failure_count == 0 else "yellow"
+            border = "yellow" if cancelled_at_group else "green"
+            if failure_count:
+                border = "yellow"
+            summary = (
+                f"Auto-group cancelled at group {cancelled_at_group}/{len(groups)}. "
+                f"{success_count} group(s) committed successfully."
+                if cancelled_at_group
+                else (
+                    f"Successful groups: {success_count}\n"
+                    f"Failed groups: {failure_count}"
+                )
+            )
             rprint(
                 Panel(
-                    (
-                        f"Successful groups: {success_count}\n"
-                        f"Failed groups: {failure_count}"
-                    ),
+                    summary,
                     title="Auto Group Complete",
                     border_style=border,
                 )
             )
+            if cancelled_at_group:
+                sys.exit(EXIT_CODE_CANCELLED)
             sys.exit(0 if failure_count == 0 else 1)
 
         # Create interaction layer and workflow

--- a/git_acp/cli/cli.py
+++ b/git_acp/cli/cli.py
@@ -34,6 +34,12 @@ from git_acp.git import (
 from git_acp.utils import GitConfig
 from git_acp.utils.file_filter import filter_files_by_scope
 
+# Single source of truth for the --type CLI option: derived from the
+# CommitType enum so choices and help text can never drift apart.
+CLI_COMMIT_TYPE_CHOICES: tuple[str, ...] = tuple(
+    ct.name.lower() for ct in CommitType
+)
+
 
 def format_commit_message(commit_type: CommitType, message: str) -> str:
     """Format a commit message according to conventional commits specification.
@@ -154,26 +160,10 @@ def _process_add_argument(add: str | None) -> tuple[str | None, bool]:
     "-t",
     "--type",
     "commit_type",
-    type=click.Choice(
-        [
-            "feat",
-            "fix",
-            "docs",
-            "style",
-            "refactor",
-            "test",
-            "chore",
-            "revert",
-            "build",
-            "ci",
-            "perf",
-        ],
-        case_sensitive=False,
-    ),
+    type=click.Choice(CLI_COMMIT_TYPE_CHOICES, case_sensitive=False),
     help=(
         "Manually specify the commit type instead of using automatic detection. "
-        "Supported types: feat, fix, docs, style, refactor, test, chore, revert, "
-        "build, ci, perf."
+        f"Supported types: {', '.join(CLI_COMMIT_TYPE_CHOICES)}."
     ),
     metavar="<type>",
 )

--- a/git_acp/cli/cli.py
+++ b/git_acp/cli/cli.py
@@ -36,9 +36,7 @@ from git_acp.utils.file_filter import filter_files_by_scope
 
 # Single source of truth for the --type CLI option: derived from the
 # CommitType enum so choices and help text can never drift apart.
-CLI_COMMIT_TYPE_CHOICES: tuple[str, ...] = tuple(
-    ct.name.lower() for ct in CommitType
-)
+CLI_COMMIT_TYPE_CHOICES: tuple[str, ...] = tuple(ct.name.lower() for ct in CommitType)
 
 
 def format_commit_message(commit_type: CommitType, message: str) -> str:

--- a/git_acp/cli/interaction.py
+++ b/git_acp/cli/interaction.py
@@ -20,6 +20,10 @@ from git_acp.git import CommitType, GitError
 from git_acp.utils import GitConfig
 
 
+class CancelledByUserError(GitError):
+    """Raised when the user cancels an interactive prompt."""
+
+
 class UserInteraction(Protocol):
     """Protocol for user interaction operations.
 
@@ -37,7 +41,8 @@ class UserInteraction(Protocol):
             Space-separated list of selected files.
 
         Raises:
-            GitError: If selection is cancelled or invalid.
+            GitError: If selection is invalid.
+            CancelledByUserError: If selection is cancelled.
         """
         ...
 
@@ -55,7 +60,8 @@ class UserInteraction(Protocol):
             The selected commit type.
 
         Raises:
-            GitError: If selection is cancelled.
+            GitError: If selection is invalid.
+            CancelledByUserError: If selection is cancelled.
         """
         ...
 
@@ -112,7 +118,8 @@ class RichQuestionaryInteraction:
             Space-separated list of selected files, with proper quoting.
 
         Raises:
-            GitError: If no files found, user cancels, or no selection made.
+            GitError: If no files are found or no files are selected.
+            CancelledByUserError: If the user cancels file selection.
         """
         if not changed_files:
             raise GitError("No changed files found to commit.")
@@ -140,7 +147,7 @@ class RichQuestionaryInteraction:
         ).ask()
 
         if selected is None:
-            raise GitError("Operation cancelled by user.")
+            raise CancelledByUserError("Operation cancelled by user.")
         elif not selected:
             raise GitError("No files selected.")
 
@@ -173,6 +180,7 @@ class RichQuestionaryInteraction:
 
         Raises:
             GitError: If no commit type is selected.
+            CancelledByUserError: If the user cancels commit type selection.
         """
         # Auto-select if skip_confirmation
         if config.skip_confirmation:
@@ -223,7 +231,7 @@ class RichQuestionaryInteraction:
         ).ask()
 
         if selected_types is None:
-            raise GitError("Operation cancelled by user.")
+            raise CancelledByUserError("Operation cancelled by user.")
         elif not selected_types or len(selected_types) != 1:
             raise GitError("No commit type selected.")
 
@@ -277,7 +285,7 @@ class RichQuestionaryInteraction:
             The stripped message, or ``None`` when the user submits empty input.
 
         Raises:
-            GitError: If the prompt is cancelled.
+            CancelledByUserError: If the prompt is cancelled.
         """
         message = cast(
             str | None,
@@ -287,7 +295,7 @@ class RichQuestionaryInteraction:
             ).ask(),
         )
         if message is None:
-            raise GitError("Operation cancelled by user.")
+            raise CancelledByUserError("Operation cancelled by user.")
         if message and message.strip():
             return message.strip()
         return None

--- a/git_acp/cli/interaction.py
+++ b/git_acp/cli/interaction.py
@@ -271,6 +271,14 @@ class RichQuestionaryInteraction:
         rprint(Panel(content, title=title, border_style=style))
 
     def _prompt_manual_commit_message(self) -> str | None:
+        """Prompt for a manual commit message.
+
+        Returns:
+            The stripped message, or ``None`` when the user submits empty input.
+
+        Raises:
+            GitError: If the prompt is cancelled.
+        """
         message = cast(
             str | None,
             questionary.text(
@@ -278,6 +286,8 @@ class RichQuestionaryInteraction:
                 style=questionary.Style(QUESTIONARY_STYLE),
             ).ask(),
         )
+        if message is None:
+            raise GitError("Operation cancelled by user.")
         if message and message.strip():
             return message.strip()
         return None

--- a/git_acp/cli/workflow.py
+++ b/git_acp/cli/workflow.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import replace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Final, Literal, cast
 
 from git_acp.ai import generate_commit_message
 from git_acp.config import COLORS
@@ -29,6 +29,12 @@ from git_acp.utils.file_filter import filter_files_by_scope
 if TYPE_CHECKING:
     from git_acp.cli.interaction import UserInteraction
     from git_acp.utils import GitConfig
+
+
+EXIT_CODE_CANCELLED: Final[int] = 2
+CANCELLED: Final[Literal["cancelled"]] = "cancelled"
+StepResult = bool | Literal["cancelled"]
+CommitTypeResult = CommitType | None | Literal["cancelled"]
 
 
 class GitWorkflow:
@@ -72,7 +78,10 @@ class GitWorkflow:
         """
         try:
             # Handle interactive file selection if needed
-            if not self._handle_file_selection():
+            file_selection = self._handle_file_selection()
+            if file_selection == CANCELLED:
+                return EXIT_CODE_CANCELLED
+            if not file_selection:
                 return 0  # No files to process, clean exit
 
             # Detect branch if not specified
@@ -88,11 +97,16 @@ class GitWorkflow:
                 return 0  # Clean exit, nothing to commit
 
             # Generate or validate commit message
-            if not self._handle_commit_message():
+            commit_message = self._handle_commit_message()
+            if commit_message == CANCELLED:
+                return EXIT_CODE_CANCELLED
+            if not commit_message:
                 return 1
 
             # Classify and select commit type
             selected_type = self._handle_commit_type()
+            if selected_type == CANCELLED:
+                return EXIT_CODE_CANCELLED
             if selected_type is None:
                 return 1
 
@@ -101,7 +115,7 @@ class GitWorkflow:
 
             # Confirm with user (if not skipping)
             if not self._handle_confirmation(formatted_message):
-                return 0  # User cancelled, clean exit
+                return EXIT_CODE_CANCELLED
 
             # Handle dry-run mode
             if self.config.dry_run:
@@ -126,7 +140,7 @@ class GitWorkflow:
             )
             return 1
 
-    def _handle_file_selection(self) -> bool:
+    def _handle_file_selection(self) -> StepResult:
         """Handle file selection phase.
 
         Returns:
@@ -168,6 +182,7 @@ class GitWorkflow:
                     "Cancelled",
                     "yellow",
                 )
+                return CANCELLED
             else:
                 self.interaction.print_error(
                     f"Error during file selection:\n{e}",
@@ -274,7 +289,7 @@ class GitWorkflow:
             return False
         return True
 
-    def _handle_commit_message(self) -> bool:
+    def _handle_commit_message(self) -> StepResult:
         """Generate or validate commit message.
 
         Returns:
@@ -296,8 +311,25 @@ class GitWorkflow:
                     "Would you like to continue with a manual commit message?"
                 ):
                     unstage_files()
+                    return CANCELLED
+                try:
+                    manual_message = self._prompt_manual_message()
+                except GitError as prompt_error:
+                    if "cancelled by user" in str(prompt_error).lower():
+                        unstage_files()
+                        self.interaction.print_panel(
+                            "Operation cancelled by user.",
+                            "Cancelled",
+                            "yellow",
+                        )
+                        return CANCELLED
+                    unstage_files()
+                    self.interaction.print_error(
+                        f"Error reading commit message:\n{prompt_error}",
+                        "Please specify a message with -m or try again.",
+                        "Commit Message Failed",
+                    )
                     return False
-                manual_message = self._prompt_manual_message()
                 if not manual_message:
                     unstage_files()
                     self.interaction.print_error(
@@ -310,7 +342,24 @@ class GitWorkflow:
                 self.config = replace(self.config, message=manual_message)
 
         if not self.config.message:
-            manual_message = self._prompt_manual_message()
+            try:
+                manual_message = self._prompt_manual_message()
+            except GitError as e:
+                if "cancelled by user" in str(e).lower():
+                    unstage_files()
+                    self.interaction.print_panel(
+                        "Operation cancelled by user.",
+                        "Cancelled",
+                        "yellow",
+                    )
+                    return CANCELLED
+                unstage_files()
+                self.interaction.print_error(
+                    f"Error reading commit message:\n{e}",
+                    "Please specify a message with -m or try again.",
+                    "Commit Message Failed",
+                )
+                return False
             if manual_message:
                 self.config = replace(self.config, message=manual_message)
             else:
@@ -337,7 +386,7 @@ class GitWorkflow:
             return typed_prompt()
         return None
 
-    def _handle_commit_type(self) -> CommitType | None:
+    def _handle_commit_type(self) -> CommitTypeResult:
         """Classify and select commit type.
 
         Returns:
@@ -397,13 +446,14 @@ class GitWorkflow:
                     "Cancelled",
                     "yellow",
                 )
+                unstage_files()
+                return CANCELLED
             else:
                 self.interaction.print_error(
                     f"Error selecting commit type:\n{e}",
                     "Try again or specify a commit type with -t.",
                     "Commit Type Selection Failed",
                 )
-            unstage_files()
             return None
 
     def _format_message(self, commit_type: CommitType) -> str:

--- a/git_acp/cli/workflow.py
+++ b/git_acp/cli/workflow.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     from git_acp.utils import GitConfig
 
 
-EXIT_CODE_CANCELLED: Final[int] = 2
+EXIT_CODE_CANCELLED: Final[int] = 130
 CANCELLED: Final[Literal["cancelled"]] = "cancelled"
 StepResult = bool | Literal["cancelled"]
 CommitTypeResult = CommitType | None | Literal["cancelled"]

--- a/git_acp/cli/workflow.py
+++ b/git_acp/cli/workflow.py
@@ -11,6 +11,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING, Final, Literal, cast
 
 from git_acp.ai import generate_commit_message
+from git_acp.cli.interaction import CancelledByUserError
 from git_acp.config import COLORS
 from git_acp.git import (
     CommitType,
@@ -174,21 +175,20 @@ class GitWorkflow:
             )
             return True
 
+        except CancelledByUserError:
+            unstage_files()
+            self.interaction.print_panel(
+                "Operation cancelled by user.",
+                "Cancelled",
+                "yellow",
+            )
+            return CANCELLED
         except GitError as e:
-            if "cancelled by user" in str(e).lower():
-                unstage_files()
-                self.interaction.print_panel(
-                    "Operation cancelled by user.",
-                    "Cancelled",
-                    "yellow",
-                )
-                return CANCELLED
-            else:
-                self.interaction.print_error(
-                    f"Error during file selection:\n{e}",
-                    "Check file paths and try again.",
-                    "File Selection Failed",
-                )
+            self.interaction.print_error(
+                f"Error during file selection:\n{e}",
+                "Check file paths and try again.",
+                "File Selection Failed",
+            )
             return False
 
     def _handle_branch_detection(self) -> bool:
@@ -314,15 +314,15 @@ class GitWorkflow:
                     return CANCELLED
                 try:
                     manual_message = self._prompt_manual_message()
+                except CancelledByUserError:
+                    unstage_files()
+                    self.interaction.print_panel(
+                        "Operation cancelled by user.",
+                        "Cancelled",
+                        "yellow",
+                    )
+                    return CANCELLED
                 except GitError as prompt_error:
-                    if "cancelled by user" in str(prompt_error).lower():
-                        unstage_files()
-                        self.interaction.print_panel(
-                            "Operation cancelled by user.",
-                            "Cancelled",
-                            "yellow",
-                        )
-                        return CANCELLED
                     unstage_files()
                     self.interaction.print_error(
                         f"Error reading commit message:\n{prompt_error}",
@@ -344,15 +344,15 @@ class GitWorkflow:
         if not self.config.message:
             try:
                 manual_message = self._prompt_manual_message()
+            except CancelledByUserError:
+                unstage_files()
+                self.interaction.print_panel(
+                    "Operation cancelled by user.",
+                    "Cancelled",
+                    "yellow",
+                )
+                return CANCELLED
             except GitError as e:
-                if "cancelled by user" in str(e).lower():
-                    unstage_files()
-                    self.interaction.print_panel(
-                        "Operation cancelled by user.",
-                        "Cancelled",
-                        "yellow",
-                    )
-                    return CANCELLED
                 unstage_files()
                 self.interaction.print_error(
                     f"Error reading commit message:\n{e}",
@@ -439,21 +439,20 @@ class GitWorkflow:
                 f"[{success}]✓ Commit type selected successfully[/{success}]"
             )
             return selected_type
+        except CancelledByUserError:
+            self.interaction.print_panel(
+                "Operation cancelled by user.",
+                "Cancelled",
+                "yellow",
+            )
+            unstage_files()
+            return CANCELLED
         except GitError as e:
-            if "cancelled by user" in str(e).lower():
-                self.interaction.print_panel(
-                    "Operation cancelled by user.",
-                    "Cancelled",
-                    "yellow",
-                )
-                unstage_files()
-                return CANCELLED
-            else:
-                self.interaction.print_error(
-                    f"Error selecting commit type:\n{e}",
-                    "Try again or specify a commit type with -t.",
-                    "Commit Type Selection Failed",
-                )
+            self.interaction.print_error(
+                f"Error selecting commit type:\n{e}",
+                "Try again or specify a commit type with -t.",
+                "Commit Type Selection Failed",
+            )
             return None
 
     def _format_message(self, commit_type: CommitType) -> str:

--- a/git_acp/config/constants.py
+++ b/git_acp/config/constants.py
@@ -118,9 +118,10 @@ FILE_PATH_PATTERNS: Final[dict[str, list[str]]] = {
         "azure-pipelines.yml",
     ],
     "perf": [
-        "benchmark",
-        "profiling",
-        "performance",
+        "benchmarks/",
+        "benchmark/",
+        "profiling/",
+        "perf/",
     ],
     "chore": [
         ".gitignore",

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -3,6 +3,9 @@
 This module provides functionality for classifying commit types and analyzing
 changes in the repository to suggest appropriate commit types.
 
+Recognized Commit Types:
+    FEAT, FIX, DOCS, STYLE, REFACTOR, TEST, CHORE, REVERT, BUILD, CI, PERF.
+
 Classification Priority:
     1. Message prefix (e.g., "feat:", "fix:") - highest priority
     2. File path patterns - deterministic and highly accurate
@@ -159,7 +162,8 @@ def group_changed_files(
 
     - Files are sorted alphabetically within each returned group.
     - Groups are ordered by:
-        1) Commit-type priority: ``docs``, ``test``, ``style``, ``chore``.
+        1) Commit-type priority: ``docs``, ``test``, ``perf``, ``style``,
+           ``build``, ``ci``, ``chore``.
         2) Directory prefix groups (lexicographic).
         3) Root-level extension groups (lexicographic).
 
@@ -182,7 +186,7 @@ def group_changed_files(
         ``FILE_PATH_PATTERNS`` and ``EXCLUDED_PATTERNS`` come from
         ``git_acp.config.constants``.
     """
-    commit_type_priority = ["docs", "test", "style", "build", "ci", "chore"]
+    commit_type_priority = ["docs", "test", "perf", "style", "build", "ci", "chore"]
 
     def is_excluded(file_path: str) -> bool:
         for pattern in EXCLUDED_PATTERNS:

--- a/git_acp/git/classification.py
+++ b/git_acp/git/classification.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from git_acp.config import (
     COMMIT_TYPE_PATTERNS,
     COMMIT_TYPES,
-    EXCLUDED_PATTERNS,
     FILE_PATH_PATTERNS,
     SIGNAL_LAYER_WEIGHTS,
 )
@@ -31,6 +30,7 @@ from git_acp.git.file_classifier import (
     _match_file_path_pattern,
     _normalize_path_separators,
     categorize_changed_files,
+    is_file_excluded,
 )
 from git_acp.git.git_operations import GitError, get_changed_files, get_diff
 from git_acp.utils import OptionalConfig, debug_header, debug_item
@@ -184,19 +184,7 @@ def group_changed_files(
     """
     commit_type_priority = ["docs", "test", "style", "build", "ci", "chore"]
 
-    def is_excluded(file_path: str) -> bool:
-        for pattern in EXCLUDED_PATTERNS:
-            # Special case for exact .env matching as defined in EXCLUDED_PATTERNS.
-            # This is hardcoded to match the "/.env$" pattern in constants.py.
-            if pattern == "/.env$":
-                if Path(file_path).name == ".env":
-                    return True
-                continue
-            if pattern in file_path:
-                return True
-        return False
-
-    remaining = sorted({f for f in files if f and not is_excluded(f)})
+    remaining = sorted({f for f in files if f and not is_file_excluded(f)})
     if not remaining:
         return []
 
@@ -567,8 +555,11 @@ def _collect_signals(
     numstat: dict[str, tuple[int, int]] = {}
     try:
         numstat = get_numstat(config)
-    except (GitError, Exception):
-        pass
+    except GitError:
+        pass  # expected: no staged/unstaged changes
+    except Exception as err:
+        if config.verbose:
+            debug_item("Numstat unexpected error", str(err))
 
     if config.verbose and numstat:
         debug_item("Numstat files", str(len(numstat)))

--- a/git_acp/git/core.py
+++ b/git_acp/git/core.py
@@ -43,6 +43,14 @@ def run_git_command(
                 debug_item("Exit Code", str(process.returncode))
                 debug_item("Error Output", stderr.strip())
 
+            stderr_lower = stderr.lower()
+            if "unable to create" in stderr_lower and "index.lock" in stderr_lower:
+                raise GitError(
+                    "Git index is locked. Another git process may be running, "
+                    "or a stale lock file exists. If no other git process is "
+                    "running, try removing '.git/index.lock' manually."
+                )
+
             error_patterns = {
                 "not a git repository": (
                     "Not a git repository. Please run this command in a git repository."
@@ -79,7 +87,7 @@ def run_git_command(
             }
 
             for pattern, message in error_patterns.items():
-                if pattern in stderr.lower():
+                if pattern in stderr_lower:
                     raise GitError(message)
 
             raise GitError(f"Git command failed: {stderr.strip()}")
@@ -105,6 +113,8 @@ def run_git_command(
             "Permission denied while executing git command. "
             "Please check your permissions."
         )
+    except GitError:
+        raise
     except Exception as e:
         if config and config.verbose:
             debug_header("Git Command Error")

--- a/git_acp/git/diff.py
+++ b/git_acp/git/diff.py
@@ -170,9 +170,7 @@ def get_numstat(config: OptionalConfig = None) -> dict[str, tuple[int, int]]:
     return result
 
 
-def extract_added_lines(
-    diff: str, excluded_files: set[str] | None = None
-) -> str:
+def extract_added_lines(diff: str, excluded_files: set[str] | None = None) -> str:
     """Extract only added lines from a unified diff.
 
     Strips the leading ``+`` from each added line. Skips ``+++ `` file

--- a/git_acp/git/diff.py
+++ b/git_acp/git/diff.py
@@ -2,12 +2,10 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from git_acp.config import EXCLUDED_PATTERNS
 from git_acp.utils import DiffType, OptionalConfig, debug_header, debug_item
 
 from .core import GitError, run_git_command
+from .file_classifier import is_file_excluded
 
 # Default line count assigned to binary files in numstat output
 # (shown as "-" in git diff --numstat).
@@ -63,28 +61,10 @@ def get_changed_files(
                 files.add(path)
 
     if files:
-        excluded_files = set()
-        for f in files:
-            for pattern in EXCLUDED_PATTERNS:
-                if pattern == "/.env$":
-                    if Path(f).name == ".env":
-                        if config and config.verbose:
-                            debug_item(
-                                "Excluding file based on pattern",
-                                f"Pattern '{pattern}' matched '{f}'",
-                            )
-                        excluded_files.add(f)
-                        break
-                    continue
-
-                if pattern in f:
-                    if config and config.verbose:
-                        debug_item(
-                            "Excluding file based on pattern",
-                            f"Pattern '{pattern}' matched '{f}'",
-                        )
-                    excluded_files.add(f)
-                    break
+        excluded_files = {f for f in files if is_file_excluded(f)}
+        for f in excluded_files:
+            if config and config.verbose:
+                debug_item("Excluding file", f)
         files -= excluded_files
 
     if config and config.verbose:
@@ -179,16 +159,7 @@ def get_numstat(config: OptionalConfig = None) -> dict[str, tuple[int, int]]:
         added = _BINARY_LINE_COUNT if added_str == "-" else int(added_str)
         removed = 0 if removed_str == "-" else int(removed_str)
 
-        # Apply exclusion filter
-        excluded = False
-        for pattern in EXCLUDED_PATTERNS:
-            if pattern == "/.env$" and Path(filepath).name == ".env":
-                excluded = True
-                break
-            if pattern in filepath:
-                excluded = True
-                break
-        if excluded:
+        if is_file_excluded(filepath):
             continue
 
         result[filepath] = (added, removed)

--- a/git_acp/git/file_classifier.py
+++ b/git_acp/git/file_classifier.py
@@ -86,6 +86,9 @@ def is_file_excluded(file_path: str) -> bool:
     represents an exact-basename match (``.env`` but not
     ``.env.example``) that cannot be expressed as a literal substring.
 
+    Args:
+        file_path: Repository-relative file path to check.
+
     Returns:
         ``True`` if the file path matches any exclusion pattern.
     """

--- a/git_acp/git/file_classifier.py
+++ b/git_acp/git/file_classifier.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import re
 from enum import Enum
+from pathlib import Path
 
-from git_acp.config import FILE_CATEGORY_PATTERNS
+from git_acp.config import EXCLUDED_PATTERNS, FILE_CATEGORY_PATTERNS
 
 
 class FileCategory(Enum):
@@ -74,6 +75,28 @@ def _match_file_path_pattern(file_path: str, pattern: str) -> bool:
         return any(seg.endswith(pattern_lower) for seg in file_segments)
 
     return any(pattern_lower in seg for seg in file_segments)
+
+
+def is_file_excluded(file_path: str) -> bool:
+    """Check whether *file_path* matches any ``EXCLUDED_PATTERNS`` entry.
+
+    Uses :func:`_match_file_path_pattern` for consistent segment-aware
+    matching, the same matcher used by file-category and commit-type
+    classification. The ``/.env$`` pattern is special-cased because it
+    represents an exact-basename match (``.env`` but not
+    ``.env.example``) that cannot be expressed as a literal substring.
+
+    Returns:
+        ``True`` if the file path matches any exclusion pattern.
+    """
+    for pattern in EXCLUDED_PATTERNS:
+        if pattern == "/.env$":
+            if Path(file_path).name == ".env":
+                return True
+            continue
+        if _match_file_path_pattern(file_path, pattern):
+            return True
+    return False
 
 
 def classify_file_category(path: str) -> FileCategory:

--- a/git_acp/git/git_operations.py
+++ b/git_acp/git/git_operations.py
@@ -6,11 +6,9 @@ It also implements ``get_changed_files`` directly so that tests can patch the
 ``run_git_command`` symbol in this module and fully control its behavior.
 """
 
-from pathlib import Path
-
-from git_acp.config import EXCLUDED_PATTERNS
 from git_acp.utils import OptionalConfig, debug_header, debug_item
 
+from .file_classifier import is_file_excluded
 from .operations import (
     GitError,
     analyze_commit_patterns,
@@ -86,28 +84,10 @@ def get_changed_files(
                 files.add(path)
 
     if files:
-        excluded_files = set()
-        for f in files:
-            for pattern in EXCLUDED_PATTERNS:
-                if pattern == "/.env$":
-                    if Path(f).name == ".env":
-                        if config and config.verbose:
-                            debug_item(
-                                "Excluding file based on pattern",
-                                f"Pattern '{pattern}' matched '{f}'",
-                            )
-                        excluded_files.add(f)
-                        break
-                    continue
-
-                if pattern in f:
-                    if config and config.verbose:
-                        debug_item(
-                            "Excluding file based on pattern",
-                            f"Pattern '{pattern}' matched '{f}'",
-                        )
-                    excluded_files.add(f)
-                    break
+        excluded_files = {f for f in files if is_file_excluded(f)}
+        for f in excluded_files:
+            if config and config.verbose:
+                debug_item("Excluding file", f)
         files -= excluded_files
 
     if config and config.verbose:
@@ -136,5 +116,4 @@ __all__ = [
     "manage_tags",
     "manage_stash",
     "setup_signal_handlers",
-    "EXCLUDED_PATTERNS",
 ]

--- a/project-overview.md
+++ b/project-overview.md
@@ -1,7 +1,7 @@
 ---
 repo: https://github.com/beecave-homelab/git-acp.git
 commit: 60cb407
-updated: 2026-06-07T00:00:00Z
+updated: 2026-06-24T00:00:00Z
 ---
 <!-- markdownlint-disable-file MD033 -->
 <!-- SECTIONS:API,CLI,WEBUI,CI,DOCKER,TESTS -->
@@ -11,7 +11,7 @@ updated: 2026-06-07T00:00:00Z
 `git-acp` is a command-line tool that automates the `git add`, `commit`, and `push` workflow. It offers interactive file selection, AI-powered commit message generation via Ollama, and enforces Conventional Commits standards.
 
 ![Language](https://img.shields.io/badge/Python-3.10+-blue)
-[![Version](https://img.shields.io/badge/Version-0.26.0-brightgreen)](#version-summary)
+[![Version](https://img.shields.io/badge/Version-0.27.0-brightgreen)](#version-summary)
 [![CLI](https://img.shields.io/badge/CLI-Click-blue)](#cli)
 [![Coverage](https://img.shields.io/badge/Coverage-97%25-brightgreen)](#tests)
 
@@ -61,6 +61,7 @@ pdm export --pyproject --no-hashes -G lint,test -o requirements.dev.txt
 
 | Version | Date | Type | Key Changes |
 | ------- | ---- | ---- | ----------- |
+| 0.27.0 | 24-06-2026 | 🐛 | Abort auto-group on cancellation, improve index-lock errors, centralize exclusions, and tighten perf/build grouping |
 | 0.26.0 | 07-06-2026 | ✨ | Add weighted scoring classifier, file analysis infrastructure, and build/ci/perf commit types |
 | 0.25.0 | 04-06-2026 | ✨ | Add `--setup` flag to automate initial `.env` config creation |
 | 0.24.0 | 24-05-2026 | ✨ | Emoji-aware prefix stripping, scoped `-a` filtering, auto-group, dry-run, mypy integration |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "git-acp"
-version = "0.26.0"
+version = "0.27.0"
 authors = [
     { name = "elvee" },
 ]

--- a/tests/cli/test_auto_group.py
+++ b/tests/cli/test_auto_group.py
@@ -7,6 +7,7 @@ from unittest.mock import ANY, MagicMock, call, patch
 from click.testing import CliRunner
 
 from git_acp.cli.cli import main
+from git_acp.cli.workflow import EXIT_CODE_CANCELLED
 
 
 class TestCliAutoGroup:
@@ -163,3 +164,71 @@ class TestCliAutoGroup:
         assert second_config.files == "tests/cli/test_workflow.py"
 
         assert mock_unstage.call_count == 2
+
+    @patch("git_acp.cli.cli.unstage_files")
+    @patch("git_acp.cli.cli.GitWorkflow")
+    @patch("git_acp.cli.cli.group_changed_files")
+    @patch("git_acp.cli.cli.get_changed_files")
+    def test_auto_group_stops_when_first_group_is_cancelled(
+        self,
+        mock_get_changed_files: MagicMock,
+        mock_group_changed_files: MagicMock,
+        mock_workflow_cls: MagicMock,
+        mock_unstage: MagicMock,
+    ) -> None:
+        """Stop processing groups when the first workflow is cancelled."""
+        mock_get_changed_files.side_effect = [
+            set(),
+            {"a.py", "b.py"},
+            set(),
+        ]
+        mock_group_changed_files.return_value = [["a.py"], ["b.py"]]
+
+        workflow_one = MagicMock()
+        workflow_one.run.return_value = EXIT_CODE_CANCELLED
+        mock_workflow_cls.return_value = workflow_one
+
+        result = self.runner.invoke(main, ["--auto-group", "--no-confirm"])
+
+        assert result.exit_code == EXIT_CODE_CANCELLED
+        assert mock_workflow_cls.call_count == 1
+        assert workflow_one.run.call_count == 1
+        assert mock_unstage.call_args_list == [call(ANY)]
+        assert "Auto-group cancelled at group 1/2" in result.output
+        assert "0 group(s) committed successfully" in result.output
+
+    @patch("git_acp.cli.cli.unstage_files")
+    @patch("git_acp.cli.cli.GitWorkflow")
+    @patch("git_acp.cli.cli.group_changed_files")
+    @patch("git_acp.cli.cli.get_changed_files")
+    def test_auto_group_reports_successes_before_later_cancellation(
+        self,
+        mock_get_changed_files: MagicMock,
+        mock_group_changed_files: MagicMock,
+        mock_workflow_cls: MagicMock,
+        mock_unstage: MagicMock,
+    ) -> None:
+        """Report committed groups when cancellation happens after successes."""
+        mock_get_changed_files.side_effect = [
+            set(),
+            {"a.py", "b.py", "c.py"},
+            set(),
+            set(),
+        ]
+        mock_group_changed_files.return_value = [["a.py"], ["b.py"], ["c.py"]]
+
+        workflow_one = MagicMock()
+        workflow_one.run.return_value = 0
+        workflow_two = MagicMock()
+        workflow_two.run.return_value = EXIT_CODE_CANCELLED
+        mock_workflow_cls.side_effect = [workflow_one, workflow_two]
+
+        result = self.runner.invoke(main, ["--auto-group", "--no-confirm"])
+
+        assert result.exit_code == EXIT_CODE_CANCELLED
+        assert mock_workflow_cls.call_count == 2
+        assert workflow_one.run.call_count == 1
+        assert workflow_two.run.call_count == 1
+        assert mock_unstage.call_args_list == [call(ANY), call(ANY)]
+        assert "Auto-group cancelled at group 2/3" in result.output
+        assert "1 group(s) committed successfully" in result.output

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -176,8 +176,8 @@ class TestCli(unittest.TestCase):
         """CLI_COMMIT_TYPE_CHOICES must match CommitType enum members."""
         from git_acp.cli.cli import CLI_COMMIT_TYPE_CHOICES
 
-        enum_types = {ct.name.lower() for ct in CommitType}
-        self.assertEqual(set(CLI_COMMIT_TYPE_CHOICES), enum_types)
+        enum_types = [ct.name.lower() for ct in CommitType]
+        self.assertEqual(list(CLI_COMMIT_TYPE_CHOICES), enum_types)
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -172,6 +172,13 @@ class TestCli(unittest.TestCase):
         self.assertEqual(result.exit_code, 2)
         self.assertIn("Invalid value", result.output)
 
+    def test_cli_type_choices_match_committype_enum(self) -> None:
+        """CLI_COMMIT_TYPE_CHOICES must match CommitType enum members."""
+        from git_acp.cli.cli import CLI_COMMIT_TYPE_CHOICES
+
+        enum_types = {ct.name.lower() for ct in CommitType}
+        self.assertEqual(set(CLI_COMMIT_TYPE_CHOICES), enum_types)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from git_acp.cli.interaction import TestInteraction
-from git_acp.cli.workflow import GitWorkflow
+from git_acp.cli.workflow import EXIT_CODE_CANCELLED, GitWorkflow
 from git_acp.git import CommitType, GitError
 from git_acp.utils import GitConfig
 
@@ -314,7 +314,7 @@ class TestGitWorkflow:
         mock_classify: MagicMock,
         mock_config: GitConfig,
     ) -> None:
-        """Return zero exit code when user cancels at confirmation."""
+        """Return cancellation exit code when user cancels at confirmation."""
         from git_acp.cli.interaction import TestInteraction
         from git_acp.cli.workflow import GitWorkflow
 
@@ -326,7 +326,7 @@ class TestGitWorkflow:
 
         exit_code = workflow.run()
 
-        assert exit_code == 0
+        assert exit_code == EXIT_CODE_CANCELLED
         mock_unstage.assert_called_once_with()
         mock_commit.assert_not_called()
         mock_push.assert_not_called()
@@ -580,7 +580,7 @@ class TestWorkflowErrorPaths:
         mock_unstage: MagicMock,
         interactive_config: GitConfig,
     ) -> None:
-        """Handle user cancellation during file selection."""
+        """Return cancellation exit code when file selection is cancelled."""
         from git_acp.cli.interaction import TestInteraction
         from git_acp.cli.workflow import GitWorkflow
 
@@ -591,7 +591,7 @@ class TestWorkflowErrorPaths:
 
         exit_code = workflow.run()
 
-        assert exit_code == 0  # Clean exit on cancel
+        assert exit_code == EXIT_CODE_CANCELLED
         mock_unstage.assert_called()
 
     @patch("git_acp.cli.workflow.get_current_branch")
@@ -665,7 +665,7 @@ class TestWorkflowErrorPaths:
 
         exit_code = workflow.run()
 
-        assert exit_code == 1
+        assert exit_code == EXIT_CODE_CANCELLED
         mock_unstage.assert_called_once_with()
 
     @patch("git_acp.cli.workflow.unstage_files")
@@ -702,7 +702,7 @@ class TestWorkflowErrorPaths:
         mock_classify: MagicMock,
         mock_config: GitConfig,
     ) -> None:
-        """Handle cancellation during commit type selection."""
+        """Return cancellation exit code when commit type selection is cancelled."""
         from git_acp.cli.interaction import TestInteraction
         from git_acp.cli.workflow import GitWorkflow
 
@@ -720,7 +720,58 @@ class TestWorkflowErrorPaths:
 
         exit_code = workflow.run()
 
-        assert exit_code == 1
+        assert exit_code == EXIT_CODE_CANCELLED
+        mock_unstage.assert_called_once_with()
+
+    @patch("git_acp.cli.workflow.unstage_files")
+    @patch("git_acp.cli.workflow.git_add")
+    def test_workflow__manual_message_prompt_cancelled(
+        self,
+        mock_add: MagicMock,
+        mock_unstage: MagicMock,
+        mock_config: GitConfig,
+    ) -> None:
+        """Return cancellation exit code when manual message prompt is cancelled."""
+        mock_config.message = None
+        mock_config.use_ollama = False
+
+        class CancellingInteraction(TestInteraction):
+            def _prompt_manual_commit_message(self) -> str | None:
+                raise GitError("Operation cancelled by user.")
+
+        interaction = CancellingInteraction()
+        workflow = GitWorkflow(mock_config, interaction)
+
+        exit_code = workflow.run()
+
+        assert exit_code == EXIT_CODE_CANCELLED
+        mock_unstage.assert_called_once_with()
+
+    @patch("git_acp.cli.workflow.generate_commit_message")
+    @patch("git_acp.cli.workflow.unstage_files")
+    @patch("git_acp.cli.workflow.git_add")
+    def test_workflow__ai_fallback_manual_message_prompt_cancelled(
+        self,
+        mock_add: MagicMock,
+        mock_unstage: MagicMock,
+        mock_generate: MagicMock,
+        mock_config: GitConfig,
+    ) -> None:
+        """Return cancellation exit code when AI fallback prompt is cancelled."""
+        mock_config.use_ollama = True
+        mock_config.message = None
+        mock_generate.side_effect = GitError("AI unavailable")
+
+        class CancellingInteraction(TestInteraction):
+            def _prompt_manual_commit_message(self) -> str | None:
+                raise GitError("Operation cancelled by user.")
+
+        interaction = CancellingInteraction(confirm_response=True)
+        workflow = GitWorkflow(mock_config, interaction)
+
+        exit_code = workflow.run()
+
+        assert exit_code == EXIT_CODE_CANCELLED
         mock_unstage.assert_called_once_with()
 
 

--- a/tests/cli/test_workflow.py
+++ b/tests/cli/test_workflow.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from git_acp.cli.interaction import TestInteraction
+from git_acp.cli.interaction import CancelledByUserError, TestInteraction
 from git_acp.cli.workflow import EXIT_CODE_CANCELLED, GitWorkflow
 from git_acp.git import CommitType, GitError
 from git_acp.utils import GitConfig
@@ -584,9 +584,18 @@ class TestWorkflowErrorPaths:
         from git_acp.cli.interaction import TestInteraction
         from git_acp.cli.workflow import GitWorkflow
 
-        mock_get_changed.side_effect = GitError("Operation cancelled by user.")
+        mock_get_changed.return_value = {"README.md"}
 
-        interaction = TestInteraction()
+        class CancellingInteraction(TestInteraction):
+            def select_files(self, changed_files: set[str]) -> str:
+                """Raise cancellation from the interactive file picker.
+
+                Raises:
+                    CancelledByUserError: Always raised for this test double.
+                """
+                raise CancelledByUserError("Operation cancelled by user.")
+
+        interaction = CancellingInteraction()
         workflow = GitWorkflow(interactive_config, interaction)
 
         exit_code = workflow.run()
@@ -713,7 +722,7 @@ class TestWorkflowErrorPaths:
             def select_commit_type(
                 self, suggested: CommitType, config: GitConfig, commit_message: str
             ) -> CommitType:
-                raise GitError("Operation cancelled by user.")
+                raise CancelledByUserError("Operation cancelled by user.")
 
         interaction = CancellingInteraction()
         workflow = GitWorkflow(mock_config, interaction)
@@ -737,7 +746,7 @@ class TestWorkflowErrorPaths:
 
         class CancellingInteraction(TestInteraction):
             def _prompt_manual_commit_message(self) -> str | None:
-                raise GitError("Operation cancelled by user.")
+                raise CancelledByUserError("Operation cancelled by user.")
 
         interaction = CancellingInteraction()
         workflow = GitWorkflow(mock_config, interaction)
@@ -764,7 +773,7 @@ class TestWorkflowErrorPaths:
 
         class CancellingInteraction(TestInteraction):
             def _prompt_manual_commit_message(self) -> str | None:
-                raise GitError("Operation cancelled by user.")
+                raise CancelledByUserError("Operation cancelled by user.")
 
         interaction = CancellingInteraction(confirm_response=True)
         workflow = GitWorkflow(mock_config, interaction)

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -14,7 +14,11 @@ from git_acp.git.classification import (
     strip_conventional_prefix,
 )
 from git_acp.git.diff import extract_added_lines
-from git_acp.git.file_classifier import categorize_changed_files, classify_file_category
+from git_acp.git.file_classifier import (
+    categorize_changed_files,
+    classify_file_category,
+    is_file_excluded,
+)
 from git_acp.git.git_operations import GitError
 
 
@@ -552,6 +556,69 @@ class TestClassifyCommitTypeEdgeCases:
         mock_debug_header.assert_any_call("Commit Classification Result")
         mock_debug_item.assert_any_call("Source", "scoring")
 
+    @patch("git_acp.git.classification.get_numstat")
+    @patch("git_acp.git.classification.get_changed_files")
+    @patch("git_acp.git.classification.get_diff")
+    @patch("git_acp.git.classification.debug_item")
+    def test_numstat__unexpected_error_logged_verbose(
+        self,
+        mock_debug_item,
+        mock_get_diff,
+        mock_get_files,
+        mock_get_numstat,
+        verbose_config,
+    ):
+        """Unexpected numstat errors are logged, not silently swallowed."""
+        mock_get_files.return_value = set()
+        mock_get_diff.return_value = "minor change"
+        mock_get_numstat.side_effect = RuntimeError("numstat blew up")
+
+        result = classify_commit_type(verbose_config)
+
+        # Classification should still succeed (CHORE default)
+        assert result == CommitType.CHORE
+        # The unexpected error should have been logged
+        mock_debug_item.assert_any_call(
+            "Numstat unexpected error", "numstat blew up"
+        )
+
+    @patch("git_acp.git.classification.get_numstat")
+    @patch("git_acp.git.classification.get_changed_files")
+    @patch("git_acp.git.classification.get_diff")
+    def test_numstat__unexpected_error_silent_non_verbose(
+        self,
+        mock_get_diff,
+        mock_get_files,
+        mock_get_numstat,
+        mock_config,
+    ):
+        """Unexpected numstat errors are silently absorbed in non-verbose mode."""
+        mock_get_files.return_value = set()
+        mock_get_diff.return_value = "minor change"
+        mock_get_numstat.side_effect = ValueError("corrupt numstat")
+
+        # Should not raise — classification proceeds with empty numstat
+        result = classify_commit_type(mock_config)
+        assert result == CommitType.CHORE
+
+    @patch("git_acp.git.classification.get_numstat")
+    @patch("git_acp.git.classification.get_changed_files")
+    @patch("git_acp.git.classification.get_diff")
+    def test_numstat__git_error_always_silent(
+        self,
+        mock_get_diff,
+        mock_get_files,
+        mock_get_numstat,
+        verbose_config,
+    ):
+        """GitError from numstat is expected (no changes), always silent."""
+        mock_get_files.return_value = set()
+        mock_get_diff.return_value = "minor change"
+        mock_get_numstat.side_effect = GitError("no staged changes")
+
+        result = classify_commit_type(verbose_config)
+        assert result == CommitType.CHORE
+
 
 class TestStripConventionalPrefix:
     """Tests for stripping conventional prefixes from commit titles."""
@@ -703,6 +770,39 @@ class TestFileClassifier:
         assert FileCategory.DEPENDENCY in result
         assert "src/main.py" in result[FileCategory.PRODUCTION]
         assert "tests/test_main.py" in result[FileCategory.TEST]
+
+
+class TestIsFileExcluded:
+    """Tests for is_file_excluded — shared exclusion logic."""
+
+    def test_excludes_env_file(self) -> None:
+        """Exact .env basename is excluded."""
+        assert is_file_excluded(".env")
+        assert is_file_excluded("config/.env")
+
+    def test_does_not_exclude_env_example(self) -> None:
+        """.env.example should not be excluded (only exact .env match)."""
+        assert not is_file_excluded(".env.example")
+        assert not is_file_excluded("config/.env.local")
+
+    def test_excludes_pycache(self) -> None:
+        """__pycache__ paths matching EXCLUDED_PATTERNS are excluded."""
+        assert is_file_excluded("__pycache__/module.cpython-311.pyc")
+
+    def test_excludes_node_modules(self) -> None:
+        """node_modules paths are excluded."""
+        assert is_file_excluded("node_modules/react/index.js")
+
+    def test_does_not_exclude_source_file(self) -> None:
+        """Regular source files are not excluded."""
+        assert not is_file_excluded("src/main.py")
+        assert not is_file_excluded("git_acp/cli/cli.py")
+
+    def test_segment_aware_matching(self) -> None:
+        """Pattern matches on path segments, not arbitrary substrings."""
+        # 'lock' as a substring exists in 'deadlock.py', but segment-aware
+        # matching should not flag it because 'lock' is not a full segment.
+        assert not is_file_excluded("src/deadlock.py")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -775,30 +775,30 @@ class TestFileClassifier:
 class TestIsFileExcluded:
     """Tests for is_file_excluded — shared exclusion logic."""
 
-    def test_excludes_env_file(self) -> None:
+    def test_is_file_excluded__excludes_env_file(self) -> None:
         """Exact .env basename is excluded."""
         assert is_file_excluded(".env")
         assert is_file_excluded("config/.env")
 
-    def test_does_not_exclude_env_example(self) -> None:
+    def test_is_file_excluded__does_not_exclude_env_example(self) -> None:
         """.env.example should not be excluded (only exact .env match)."""
         assert not is_file_excluded(".env.example")
         assert not is_file_excluded("config/.env.local")
 
-    def test_excludes_pycache(self) -> None:
+    def test_is_file_excluded__excludes_pycache(self) -> None:
         """__pycache__ paths matching EXCLUDED_PATTERNS are excluded."""
         assert is_file_excluded("__pycache__/module.cpython-311.pyc")
 
-    def test_excludes_node_modules(self) -> None:
+    def test_is_file_excluded__excludes_node_modules(self) -> None:
         """node_modules paths are excluded."""
         assert is_file_excluded("node_modules/react/index.js")
 
-    def test_does_not_exclude_source_file(self) -> None:
+    def test_is_file_excluded__does_not_exclude_source_file(self) -> None:
         """Regular source files are not excluded."""
         assert not is_file_excluded("src/main.py")
         assert not is_file_excluded("git_acp/cli/cli.py")
 
-    def test_segment_aware_matching(self) -> None:
+    def test_is_file_excluded__segment_aware_matching(self) -> None:
         """Pattern matches on path segments, not arbitrary substrings."""
         # 'lock' as a substring exists in 'deadlock.py', but segment-aware
         # matching should not flag it because 'lock' is not a full segment.

--- a/tests/git/test_classification.py
+++ b/tests/git/test_classification.py
@@ -578,9 +578,7 @@ class TestClassifyCommitTypeEdgeCases:
         # Classification should still succeed (CHORE default)
         assert result == CommitType.CHORE
         # The unexpected error should have been logged
-        mock_debug_item.assert_any_call(
-            "Numstat unexpected error", "numstat blew up"
-        )
+        mock_debug_item.assert_any_call("Numstat unexpected error", "numstat blew up")
 
     @patch("git_acp.git.classification.get_numstat")
     @patch("git_acp.git.classification.get_changed_files")

--- a/tests/git/test_core.py
+++ b/tests/git/test_core.py
@@ -213,6 +213,25 @@ class TestRunGitCommand:
         assert "Cannot lock ref" in str(exc.value)
 
     @patch("subprocess.Popen")
+    def test_run_git_command__index_lock_error(
+        self, mock_popen: MagicMock, mock_config: GitConfig
+    ) -> None:
+        """Map index.lock failures to a helpful recovery message."""
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (
+            "",
+            "fatal: Unable to create '.git/index.lock': File exists.",
+        )
+        mock_process.returncode = 128
+        mock_popen.return_value = mock_process
+
+        with pytest.raises(GitError) as exc:
+            run_git_command(["git", "reset", "HEAD"], mock_config)
+
+        assert "Git index is locked" in str(exc.value)
+        assert ".git/index.lock" in str(exc.value)
+
+    @patch("subprocess.Popen")
     def test_run_git_command__unrelated_histories(
         self, mock_popen: MagicMock, mock_config: GitConfig
     ) -> None:

--- a/tests/git/test_grouping.py
+++ b/tests/git/test_grouping.py
@@ -15,12 +15,18 @@ class TestGroupChangedFiles:
         assert group_changed_files(set()) == []
 
     def test_commit_type_priority_ordering(self) -> None:
-        """Group commit-types first and respect priority ordering."""
+        """Group commit-types first and respect priority ordering.
+
+        Priority order is docs, test, perf, style, build, ci, chore.
+        """
         files = {
             "tests/test_core.py",
             "docs/intro.md",
+            "benchmarks/bench_core.py",
             "pyproject.toml",
             "ruff.toml",
+            "Dockerfile",
+            ".github/workflows/ci.yml",
         }
 
         groups = group_changed_files(files)
@@ -28,9 +34,34 @@ class TestGroupChangedFiles:
         assert groups == [
             ["docs/intro.md"],
             ["tests/test_core.py"],
+            ["benchmarks/bench_core.py"],
             ["ruff.toml"],
+            ["Dockerfile"],
+            [".github/workflows/ci.yml"],
             ["pyproject.toml"],
         ]
+
+    def test_build_files_grouped_as_build(self) -> None:
+        """Build files form a build type group instead of extension groups."""
+        files = {
+            "Dockerfile",
+            "docker-compose.yml",
+        }
+
+        groups = group_changed_files(files)
+
+        assert groups == [["Dockerfile", "docker-compose.yml"]]
+
+    def test_perf_files_grouped_as_perf(self) -> None:
+        """Benchmark and profiling files form a perf type group."""
+        files = {
+            "benchmarks/bench_core.py",
+            "profiling/trace.py",
+        }
+
+        groups = group_changed_files(files)
+
+        assert groups == [["benchmarks/bench_core.py", "profiling/trace.py"]]
 
     def test_files_sorted_within_each_group(self) -> None:
         """Sort files alphabetically within each group."""


### PR DESCRIPTION
# fix 🐛: Abort auto-group after cancellation

## Summary

Fixes auto-group cancellation so a cancelled group aborts the remaining run, cleans up staged files, and reports a cancellation exit code instead of continuing to later groups.

## Why

- Addresses #88, where cancelling an auto-group prompt allowed later groups to continue.
- Prevents partial staged state from being left behind after cancellation.
- Improves the Git index-lock error message with actionable recovery guidance.

## Notable changes (reviewer focus)

- Adds `EXIT_CODE_CANCELLED` and explicit cancellation propagation through `GitWorkflow`.
- Stops the auto-group loop as soon as a group returns the cancellation exit code.
- Ensures manual-message prompt cancellation is treated as cancellation rather than empty input.
- Keeps defensive `unstage_files()` cleanup after each auto-group iteration.
- Maps `.git/index.lock` failures to a clearer `GitError` message.

## Files changed

- **Counts:** 7 files changed (0 added, 7 modified, 0 deleted).
- **Key touchpoints:** CLI auto-group orchestration, interaction prompt handling, workflow cancellation handling, Git command error mapping, workflow/auto-group/core tests.

<details>
<summary>File lists (auto)</summary>

### Added
- N/A

### Modified
- `git_acp/cli/cli.py`
- `git_acp/cli/interaction.py`
- `git_acp/cli/workflow.py`
- `git_acp/git/core.py`
- `tests/cli/test_auto_group.py`
- `tests/cli/test_workflow.py`
- `tests/git/test_core.py`

### Deleted
- N/A

</details>

## Test plan

- [x] Unit: added cancellation and index-lock coverage in workflow, auto-group, and git core tests.
- [x] Integration: `scripts/local-ci.sh`.
- [ ] Manual: N/A.

## Risks & rollback

- **Risks:** Cancellation now returns exit code `2`, which may affect callers that treated prompt cancellation as success.
- **Risks:** Defensive unstaging runs after each auto-group iteration; this is intended but should be reviewed around existing staged-state assumptions.
- **Rollback:** Revert this PR.

## Additional notes

- Draft PR for merging `dev` into `main`.
- Closes #88.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for cancelled actions in the CLI, with a distinct exit result and improved cancellation summaries.
  * Commit type suggestions now stay in sync with the available commit types.
  * Performance-related files are now grouped more accurately for commit classification.

* **Bug Fixes**
  * Improved handling when the Git index is locked, with a clearer error message.
  * Fixed file exclusion behavior so common ignored paths are handled more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->